### PR TITLE
Small fixes to jekyll files

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <title>{{ page.title }}</title>
   <link href='http://fonts.googleapis.com/css?family=Orienta' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" type="text/css" href="http://fsharp.org/style.css" />
+  <link rel="stylesheet" type="text/css" href="/style.css" />
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
   <script type="text/javascript" src="https://www.google.com/jsapi"></script>
   <script src="http://fsharp.org/script.js" type="text/javascript"></script>

--- a/math/index.md
+++ b/math/index.md
@@ -10,7 +10,7 @@ This page provides information about using F# for numerical computing.
 
 Why is F# great for solving numerical problems...
 
-### Open-sourc libraries
+### Open-source libraries
 
 Here are some open source libraries:
 

--- a/style.css
+++ b/style.css
@@ -60,6 +60,7 @@ h1 {
   margin-left:250px;
   padding-bottom:40px;
   margin-right:20px;
+  min-height:550px;
 }
 
 /* Menu design */


### PR DESCRIPTION
I've fixed a typo on Math page, fixed the page layout of the Math page (and all default pages w/ #main2), and changed the hard-coded path to style.css from "http://fsharp.org/style.css" to "/style.css".  The path change was so that we could test changes to style.css locally.
