### PR TITLE
Fix broken links on safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,11 +82,11 @@ headline: The F# Software Foundation
     <p>Commercial and community users of F# provide stacks for developing F# applications including the following areas:
     </p>
     <ul>
-      <li><a href="webstacks\index.html">Web Stacks</a></li>
+      <li><a href="webstacks/index.html">Web Stacks</a></li>
       <li>Math Stacks</li>
       <li>Big Data Stacks</li>
       <li>Scalable Compute Stacks</li>
-      <li><a href="games\index.html">Game and Visualisation stacks</a></li>
+      <li><a href="games/index.html">Game and Visualisation stacks</a></li>
     </ul>
 
     <h4>Contributors to F#</h4>


### PR DESCRIPTION
use / instead of \ for correct links
