### PR TITLE
Update videos pages markup so that it passes Jekyll's XML validation

### DIFF
--- a/videos/1.md
+++ b/videos/1.md
@@ -4,8 +4,182 @@ title: F# Videos | Page 1
 headline: F# Talks, Tutorials and Podcasts
 ---
 
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Events/TechEd/NorthAmerica/2013/DEV-B324'><img src='http://video.ch9.ms/sessions/teched/na/2013/DEV-B324.jpg' alt='Build Data-Rich Solutions Faster with Microsoft Visual F#' style='height: 120px;'/></a><h4>Build Data-Rich Solutions Faster with Microsoft Visual F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='https://www.youtube.com/watch?v=USw0o9Fccac'><img src='https://i2.ytimg.com/vi/USw0o9Fccac/mqdefault.jpg' alt='Data Science with Hive from Tsunami' style='height: 120px;'/></a><h4>Data Science with Hive from Tsunami</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://skillsmatter.com/podcast/open-source-dot-net/f-embedded-in-excel'><img src='http://skillsmatter.com/custom/images/skills-matter_150x60_logo_2010.gif' alt='F# embedded in Excel' style='height: 120px;'/></a><h4>F# embedded in Excel</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://skillsmatter.com/podcast/open-source-dot-net/f-embedded-in-excel-part-2'><img src='http://skillsmatter.com/custom/images/skills-matter_150x60_logo_2010.gif' alt='F# embedded in Excel part 2' style='height: 120px;'/></a><h4>F# embedded in Excel part 2</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/64695094'><img src='http://b.vimeocdn.com/ts/435/436/435436548_295.jpg' alt='Dmitry Morozov on F# MVC for WPF' style='height: 120px;'/></a><h4>Dmitry Morozov on F# MVC for WPF</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=VoxlpDzWJEA'><img src='http://i3.ytimg.com/vi/VoxlpDzWJEA/mqdefault.jpg' alt='Tsunami Excel with UDFs' style='height: 120px;'/></a><h4>Tsunami Excel with UDFs</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=_BOST3W88-Y'><img src='http://i4.ytimg.com/vi/_BOST3W88-Y/mqdefault.jpg' alt='Visualize World Bank data in R with F# Type Providers' style='height: 120px;'/></a><h4>Visualize World Bank data in R with F# Type Providers</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/63376677'><img src='http://b.vimeocdn.com/ts/433/611/433611917_295.jpg' alt='Supervision: Static Analysis for Microsofts Dynamics NAV' style='height: 120px;'/></a><h4>Supervision: Static Analysis for Microsofts Dynamics NAV</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=StaP_L6xLUg'><img src='http://i4.ytimg.com/vi/StaP_L6xLUg/mqdefault.jpg' alt='Deploying Web Apps to the Cloud (Part 1)' style='height: 120px;'/></a><h4>Deploying Web Apps to the Cloud (Part 1)</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=XsNa2LbIdFA'><img src='http://i1.ytimg.com/vi/XsNa2LbIdFA/mqdefault.jpg' alt='FCell: Creating Excel UDFs in F#' style='height: 120px;'/></a><h4>FCell: Creating Excel UDFs in F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=g3VcjXGhp9U'><img src='http://i4.ytimg.com/vi/g3VcjXGhp9U/mqdefault.jpg' alt='FCell: Tsunami F# Editor in Action' style='height: 120px;'/></a><h4>FCell: Tsunami F# Editor in Action</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=9ri0RpT4mMo'><img src='http://i2.ytimg.com/vi/9ri0RpT4mMo/mqdefault.jpg' alt='FCell Type Provider' style='height: 120px;'/></a><h4>FCell Type Provider</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=GbahmjW3J5Q'><img src='http://i4.ytimg.com/vi/GbahmjW3J5Q/mqdefault.jpg' alt='Rhino 3D with F#' style='height: 120px;'/></a><h4>Rhino 3D with F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=13_4EUJ0v4A'><img src='http://i2.ytimg.com/vi/13_4EUJ0v4A/mqdefault.jpg' alt='{m}brace on Windows Azure - A distributed GREP algorithm' style='height: 120px;'/></a><h4>{m}brace on Windows Azure - A distributed GREP algorithm</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/59499238'><img src='http://b.vimeocdn.com/ts/413/531/413531764_295.jpg' alt='IntelliFactory CloudSharper' style='height: 120px;'/></a><h4>IntelliFactory CloudSharper</h4></div></li></ul></div><div class='pagination pagination-centered'><ul><li class='disabled'><a href='#'>«</a></li><li class='active'><a href='1'>1<li><a href='2'>2<li><a href='3'>3<li><a href='4'>4<li><a href='5'>5<li><a href='6'>6<li><a href='7'>7<li><a href='8'>8<li><a href='9'>9<li><a href='2'>»</a></li></ul></div>
+<div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Events/TechEd/NorthAmerica/2013/DEV-B324">
+            <img src="http://video.ch9.ms/sessions/teched/na/2013/DEV-B324.jpg" alt="Build Data-Rich Solutions Faster with Microsoft Visual F#" style="height: 120px;" />
+          </a>
+          <h4>Build Data-Rich Solutions Faster with Microsoft Visual F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="https://www.youtube.com/watch?v=USw0o9Fccac">
+            <img src="https://i2.ytimg.com/vi/USw0o9Fccac/mqdefault.jpg" alt="Data Science with Hive from Tsunami" style="height: 120px;" />
+          </a>
+          <h4>Data Science with Hive from Tsunami</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://skillsmatter.com/podcast/open-source-dot-net/f-embedded-in-excel">
+            <img src="http://skillsmatter.com/custom/images/skills-matter_150x60_logo_2010.gif" alt="F# embedded in Excel" style="height: 120px;" />
+          </a>
+          <h4>F# embedded in Excel</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://skillsmatter.com/podcast/open-source-dot-net/f-embedded-in-excel-part-2">
+            <img src="http://skillsmatter.com/custom/images/skills-matter_150x60_logo_2010.gif" alt="F# embedded in Excel part 2" style="height: 120px;" />
+          </a>
+          <h4>F# embedded in Excel part 2</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/64695094">
+            <img src="http://b.vimeocdn.com/ts/435/436/435436548_295.jpg" alt="Dmitry Morozov on F# MVC for WPF" style="height: 120px;" />
+          </a>
+          <h4>Dmitry Morozov on F# MVC for WPF</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=VoxlpDzWJEA">
+            <img src="http://i3.ytimg.com/vi/VoxlpDzWJEA/mqdefault.jpg" alt="Tsunami Excel with UDFs" style="height: 120px;" />
+          </a>
+          <h4>Tsunami Excel with UDFs</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=_BOST3W88-Y">
+            <img src="http://i4.ytimg.com/vi/_BOST3W88-Y/mqdefault.jpg" alt="Visualize World Bank data in R with F# Type Providers" style="height: 120px;" />
+          </a>
+          <h4>Visualize World Bank data in R with F# Type Providers</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/63376677">
+            <img src="http://b.vimeocdn.com/ts/433/611/433611917_295.jpg" alt="Supervision: Static Analysis for Microsofts Dynamics NAV" style="height: 120px;" />
+          </a>
+          <h4>Supervision: Static Analysis for Microsofts Dynamics NAV</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=StaP_L6xLUg">
+            <img src="http://i4.ytimg.com/vi/StaP_L6xLUg/mqdefault.jpg" alt="Deploying Web Apps to the Cloud (Part 1)" style="height: 120px;" />
+          </a>
+          <h4>Deploying Web Apps to the Cloud (Part 1)</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=XsNa2LbIdFA">
+            <img src="http://i1.ytimg.com/vi/XsNa2LbIdFA/mqdefault.jpg" alt="FCell: Creating Excel UDFs in F#" style="height: 120px;" />
+          </a>
+          <h4>FCell: Creating Excel UDFs in F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=g3VcjXGhp9U">
+            <img src="http://i4.ytimg.com/vi/g3VcjXGhp9U/mqdefault.jpg" alt="FCell: Tsunami F# Editor in Action" style="height: 120px;" />
+          </a>
+          <h4>FCell: Tsunami F# Editor in Action</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=9ri0RpT4mMo">
+            <img src="http://i2.ytimg.com/vi/9ri0RpT4mMo/mqdefault.jpg" alt="FCell Type Provider" style="height: 120px;" />
+          </a>
+          <h4>FCell Type Provider</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=GbahmjW3J5Q">
+            <img src="http://i4.ytimg.com/vi/GbahmjW3J5Q/mqdefault.jpg" alt="Rhino 3D with F#" style="height: 120px;" />
+          </a>
+          <h4>Rhino 3D with F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=13_4EUJ0v4A">
+            <img src="http://i2.ytimg.com/vi/13_4EUJ0v4A/mqdefault.jpg" alt="{m}brace on Windows Azure - A distributed GREP algorithm" style="height: 120px;" />
+          </a>
+          <h4>{m}brace on Windows Azure - A distributed GREP algorithm</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/59499238">
+            <img src="http://b.vimeocdn.com/ts/413/531/413531764_295.jpg" alt="IntelliFactory CloudSharper" style="height: 120px;" />
+          </a>
+          <h4>IntelliFactory CloudSharper</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="pagination pagination-centered">
+    <ul>
+      <li class="disabled">
+        <a href="#">«</a>
+      </li>
+      <li class="active">
+        <a href="1">1</a>
+      </li>
+      <li>
+        <a href="2">2</a>
+      </li>
+      <li>
+        <a href="3">3</a>
+      </li>
+      <li>
+        <a href="4">4</a>
+      </li>
+      <li>
+        <a href="5">5</a>
+      </li>
+      <li>
+        <a href="6">6</a>
+      </li>
+      <li>
+        <a href="7">7</a>
+      </li>
+      <li>
+        <a href="8">8</a>
+      </li>
+      <li>
+        <a href="9">9</a>
+      </li>
+      <li>
+        <a href="2">»</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/videos/2.md
+++ b/videos/2.md
@@ -4,8 +4,182 @@ title: F# Videos | Page 2
 headline: F# Talks, Tutorials and Podcasts
 ---
 
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/57399434'><img src='http://b.vimeocdn.com/ts/397/852/397852679_295.jpg' alt='Data exploration in the cloud with F#' style='height: 120px;'/></a><h4>Data exploration in the cloud with F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/53136114'><img src='http://b.vimeocdn.com/ts/366/841/366841027_295.jpg' alt='Introducing the F# Software Foundation' style='height: 120px;'/></a><h4>Introducing the F# Software Foundation</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/52610636'><img src='http://b.vimeocdn.com/ts/363/031/363031319_295.jpg' alt='Building Better Web Apps with FSharp' style='height: 120px;'/></a><h4>Building Better Web Apps with FSharp</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/50170965'><img src='http://b.vimeocdn.com/ts/345/790/345790066_295.jpg' alt='F# 3.0 Type Providers' style='height: 120px;'/></a><h4>F# 3.0 Type Providers</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=OzISu9udIY0'><img src='http://i4.ytimg.com/vi/OzISu9udIY0/mqdefault.jpg' alt='F# Tutorial: For Loop' style='height: 120px;'/></a><h4>F# Tutorial: For Loop</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=e4R9EfFNgLU'><img src='http://i2.ytimg.com/vi/e4R9EfFNgLU/mqdefault.jpg' alt='WPF desktop GUI app development in F# with VS Express 2012 for Web' style='height: 120px;'/></a><h4>WPF desktop GUI app development in F# with VS Express 2012 for Web</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=8MRIHwBPyPQ'><img src='http://i1.ytimg.com/vi/8MRIHwBPyPQ/mqdefault.jpg' alt='F# Tutorial: If Else' style='height: 120px;'/></a><h4>F# Tutorial: If Else</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=ugL3tqszZmQ'><img src='http://i2.ytimg.com/vi/ugL3tqszZmQ/mqdefault.jpg' alt='F# Tutorial: Addition of two numbers' style='height: 120px;'/></a><h4>F# Tutorial: Addition of two numbers</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=OWdqMTmM5Sw'><img src='http://i4.ytimg.com/vi/OWdqMTmM5Sw/mqdefault.jpg' alt='F# Tutorial: Immutable Concept' style='height: 120px;'/></a><h4>F# Tutorial: Immutable Concept</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/49045879'><img src='http://b.vimeocdn.com/ts/338/390/338390107_295.jpg' alt='Howard Mansell - F# Type Providers and the R Programming Language' style='height: 120px;'/></a><h4>Howard Mansell - F# Type Providers and the R Programming Language</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/49467255'><img src='http://b.vimeocdn.com/ts/341/340/341340995_295.jpg' alt='F# 3.0: data, services, Web, cloud, at your fingertips' style='height: 120px;'/></a><h4>F# 3.0: data, services, Web, cloud, at your fingertips</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=xlJeZ-j4Fug'><img src='http://i1.ytimg.com/vi/xlJeZ-j4Fug/mqdefault.jpg' alt='F# Tutorial: Hello World Program' style='height: 120px;'/></a><h4>F# Tutorial: Hello World Program</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/46903828'><img src='http://b.vimeocdn.com/ts/326/758/326758678_295.jpg' alt='Rachel Reese - Getting Started with F# Part 1' style='height: 120px;'/></a><h4>Rachel Reese - Getting Started with F# Part 1</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/46910967'><img src='http://b.vimeocdn.com/ts/326/803/326803675_295.jpg' alt='Rachel Reese - Getting Started with F# Part 2' style='height: 120px;'/></a><h4>Rachel Reese - Getting Started with F# Part 2</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/coding4fun/blog/PacMetroMan-Recreating-PacMan-for-Metro-with-a-little-help-from-F'><img src='http://files.channel9.msdn.com/thumbnail/9ee9112e-167e-45b3-8beb-f638153f4f07.png' alt='Pac[Metro]Man - Recreating PacMan for Metro with a little help from F#' style='height: 120px;'/></a><h4>Pac[Metro]Man - Recreating PacMan for Metro with a little help from F#</h4></div></li></ul></div><div class='pagination pagination-centered'><ul><li><a href='1'>«</a></li><li><a href='1'>1<li class='active'><a href='2'>2<li><a href='3'>3<li><a href='4'>4<li><a href='5'>5<li><a href='6'>6<li><a href='7'>7<li><a href='8'>8<li><a href='9'>9<li><a href='3'>»</a></li></ul></div>
+<div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/57399434">
+            <img src="http://b.vimeocdn.com/ts/397/852/397852679_295.jpg" alt="Data exploration in the cloud with F#" style="height: 120px;" />
+          </a>
+          <h4>Data exploration in the cloud with F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/53136114">
+            <img src="http://b.vimeocdn.com/ts/366/841/366841027_295.jpg" alt="Introducing the F# Software Foundation" style="height: 120px;" />
+          </a>
+          <h4>Introducing the F# Software Foundation</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/52610636">
+            <img src="http://b.vimeocdn.com/ts/363/031/363031319_295.jpg" alt="Building Better Web Apps with FSharp" style="height: 120px;" />
+          </a>
+          <h4>Building Better Web Apps with FSharp</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/50170965">
+            <img src="http://b.vimeocdn.com/ts/345/790/345790066_295.jpg" alt="F# 3.0 Type Providers" style="height: 120px;" />
+          </a>
+          <h4>F# 3.0 Type Providers</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=OzISu9udIY0">
+            <img src="http://i4.ytimg.com/vi/OzISu9udIY0/mqdefault.jpg" alt="F# Tutorial: For Loop" style="height: 120px;" />
+          </a>
+          <h4>F# Tutorial: For Loop</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=e4R9EfFNgLU">
+            <img src="http://i2.ytimg.com/vi/e4R9EfFNgLU/mqdefault.jpg" alt="WPF desktop GUI app development in F# with VS Express 2012 for Web" style="height: 120px;" />
+          </a>
+          <h4>WPF desktop GUI app development in F# with VS Express 2012 for Web</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=8MRIHwBPyPQ">
+            <img src="http://i1.ytimg.com/vi/8MRIHwBPyPQ/mqdefault.jpg" alt="F# Tutorial: If Else" style="height: 120px;" />
+          </a>
+          <h4>F# Tutorial: If Else</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=ugL3tqszZmQ">
+            <img src="http://i2.ytimg.com/vi/ugL3tqszZmQ/mqdefault.jpg" alt="F# Tutorial: Addition of two numbers" style="height: 120px;" />
+          </a>
+          <h4>F# Tutorial: Addition of two numbers</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=OWdqMTmM5Sw">
+            <img src="http://i4.ytimg.com/vi/OWdqMTmM5Sw/mqdefault.jpg" alt="F# Tutorial: Immutable Concept" style="height: 120px;" />
+          </a>
+          <h4>F# Tutorial: Immutable Concept</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/49045879">
+            <img src="http://b.vimeocdn.com/ts/338/390/338390107_295.jpg" alt="Howard Mansell - F# Type Providers and the R Programming Language" style="height: 120px;" />
+          </a>
+          <h4>Howard Mansell - F# Type Providers and the R Programming Language</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/49467255">
+            <img src="http://b.vimeocdn.com/ts/341/340/341340995_295.jpg" alt="F# 3.0: data, services, Web, cloud, at your fingertips" style="height: 120px;" />
+          </a>
+          <h4>F# 3.0: data, services, Web, cloud, at your fingertips</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=xlJeZ-j4Fug">
+            <img src="http://i1.ytimg.com/vi/xlJeZ-j4Fug/mqdefault.jpg" alt="F# Tutorial: Hello World Program" style="height: 120px;" />
+          </a>
+          <h4>F# Tutorial: Hello World Program</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/46903828">
+            <img src="http://b.vimeocdn.com/ts/326/758/326758678_295.jpg" alt="Rachel Reese - Getting Started with F# Part 1" style="height: 120px;" />
+          </a>
+          <h4>Rachel Reese - Getting Started with F# Part 1</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/46910967">
+            <img src="http://b.vimeocdn.com/ts/326/803/326803675_295.jpg" alt="Rachel Reese - Getting Started with F# Part 2" style="height: 120px;" />
+          </a>
+          <h4>Rachel Reese - Getting Started with F# Part 2</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/coding4fun/blog/PacMetroMan-Recreating-PacMan-for-Metro-with-a-little-help-from-F">
+            <img src="http://files.channel9.msdn.com/thumbnail/9ee9112e-167e-45b3-8beb-f638153f4f07.png" alt="Pac[Metro]Man - Recreating PacMan for Metro with a little help from F#" style="height: 120px;" />
+          </a>
+          <h4>Pac[Metro]Man - Recreating PacMan for Metro with a little help from F#</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="pagination pagination-centered">
+    <ul>
+      <li>
+        <a href="1">«</a>
+      </li>
+      <li>
+        <a href="1">1</a>
+      </li>
+      <li class="active">
+        <a href="2">2</a>
+      </li>
+      <li>
+        <a href="3">3</a>
+      </li>
+      <li>
+        <a href="4">4</a>
+      </li>
+      <li>
+        <a href="5">5</a>
+      </li>
+      <li>
+        <a href="6">6</a>
+      </li>
+      <li>
+        <a href="7">7</a>
+      </li>
+      <li>
+        <a href="8">8</a>
+      </li>
+      <li>
+        <a href="9">9</a>
+      </li>
+      <li>
+        <a href="3">»</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/videos/3.md
+++ b/videos/3.md
@@ -4,8 +4,182 @@ title: F# Videos | Page 3
 headline: F# Talks, Tutorials and Podcasts
 ---
 
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47218436'><img src='http://b.vimeocdn.com/ts/328/732/328732848_295.jpg' alt='Computation Expressions in F# 3.0' style='height: 120px;'/></a><h4>Computation Expressions in F# 3.0</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/46308827'><img src='http://b.vimeocdn.com/ts/322/439/322439641_295.jpg' alt='F#, The American Dream' style='height: 120px;'/></a><h4>F#, The American Dream</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/46308390'><img src='http://b.vimeocdn.com/ts/322/433/322433506_295.jpg' alt='Mathias Brandewinder On Bumblebee' style='height: 120px;'/></a><h4>Mathias Brandewinder On Bumblebee</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/43528820'><img src='http://b.vimeocdn.com/ts/302/240/302240928_295.jpg' alt='Web development with F# ' style='height: 120px;'/></a><h4>Web development with F# </h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=HQ887aOZITY'><img src='http://i1.ytimg.com/vi/HQ887aOZITY/mqdefault.jpg' alt='An Introduction to F#' style='height: 120px;'/></a><h4>An Introduction to F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/41174802'><img src='http://b.vimeocdn.com/ts/285/053/285053113_295.jpg' alt='Tomas Petricek on F# applications: From domain model to user interface' style='height: 120px;'/></a><h4>Tomas Petricek on F# applications: From domain model to user interface</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/37477716'><img src='http://b.vimeocdn.com/ts/257/487/257487624_295.jpg' alt='Coding F# (F-Sharp, English): Get Stock Quote Data and Historical Stock Prices' style='height: 120px;'/></a><h4>Coding F# (F-Sharp, English): Get Stock Quote Data and Historical Stock Prices</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/46296644'><img src='http://b.vimeocdn.com/ts/322/338/322338329_295.jpg' alt='Units of Measure in F#' style='height: 120px;'/></a><h4>Units of Measure in F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/Charles/C9-Lectures-Donna-Malayeri-F-30-Information-Rich-Programming-1-of-1'><img src='http://ak.channel9.msdn.com/ch9/8cea/cb25a821-adea-4ded-ae32-62bf4a118cea/FSharp3DonnaMalaYeri_220.jpg' alt='C9 Lectures: Donna Malayeri - F# 3.0 - Information Rich Programming, 1 of 1' style='height: 120px;'/></a><h4>C9 Lectures: Donna Malayeri - F# 3.0 - Information Rich Programming, 1 of 1</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=4WxKFMb5i9Y'><img src='http://i1.ytimg.com/vi/4WxKFMb5i9Y/mqdefault.jpg' alt='Let There Be Functional Programming with F#' style='height: 120px;'/></a><h4>Let There Be Functional Programming with F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/39381728'><img src='http://b.vimeocdn.com/ts/271/617/271617627_295.jpg' alt='Barb: How I built a simple dynamic programming language in F#' style='height: 120px;'/></a><h4>Barb: How I built a simple dynamic programming language in F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/37477719'><img src='http://b.vimeocdn.com/ts/257/484/257484586_295.jpg' alt='Coding with LINQ, Patterns &amp; Practices' style='height: 120px;'/></a><h4>Coding with LINQ, Patterns &amp; Practices</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=GAPiihlizWQ'><img src='http://i4.ytimg.com/vi/GAPiihlizWQ/mqdefault.jpg' alt='F# (F-Sharp) Tutorial - 3.3 - Reference Values [TutorialGenius.com]' style='height: 120px;'/></a><h4>F# (F-Sharp) Tutorial - 3.3 - Reference Values [TutorialGenius.com]</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=OENr435_tuo'><img src='http://i4.ytimg.com/vi/OENr435_tuo/mqdefault.jpg' alt='F# (F-Sharp) Tutorial - 2.4 - F-Sharp Interactive [TutorialGenius.com]' style='height: 120px;'/></a><h4>F# (F-Sharp) Tutorial - 2.4 - F-Sharp Interactive [TutorialGenius.com]</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=6GWu09qHlpw'><img src='http://i3.ytimg.com/vi/6GWu09qHlpw/mqdefault.jpg' alt='F# (F-Sharp) Tutorial - 4.1 - Conditional Expressions [TutorialGenius.com]' style='height: 120px;'/></a><h4>F# (F-Sharp) Tutorial - 4.1 - Conditional Expressions [TutorialGenius.com]</h4></div></li></ul></div><div class='pagination pagination-centered'><ul><li><a href='2'>«</a></li><li><a href='1'>1<li><a href='2'>2<li class='active'><a href='3'>3<li><a href='4'>4<li><a href='5'>5<li><a href='6'>6<li><a href='7'>7<li><a href='8'>8<li><a href='9'>9<li><a href='4'>»</a></li></ul></div>
+<div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47218436">
+            <img src="http://b.vimeocdn.com/ts/328/732/328732848_295.jpg" alt="Computation Expressions in F# 3.0" style="height: 120px;" />
+          </a>
+          <h4>Computation Expressions in F# 3.0</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/46308827">
+            <img src="http://b.vimeocdn.com/ts/322/439/322439641_295.jpg" alt="F#, The American Dream" style="height: 120px;" />
+          </a>
+          <h4>F#, The American Dream</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/46308390">
+            <img src="http://b.vimeocdn.com/ts/322/433/322433506_295.jpg" alt="Mathias Brandewinder On Bumblebee" style="height: 120px;" />
+          </a>
+          <h4>Mathias Brandewinder On Bumblebee</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/43528820">
+            <img src="http://b.vimeocdn.com/ts/302/240/302240928_295.jpg" alt="Web development with F# " style="height: 120px;" />
+          </a>
+          <h4>Web development with F# </h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=HQ887aOZITY">
+            <img src="http://i1.ytimg.com/vi/HQ887aOZITY/mqdefault.jpg" alt="An Introduction to F#" style="height: 120px;" />
+          </a>
+          <h4>An Introduction to F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/41174802">
+            <img src="http://b.vimeocdn.com/ts/285/053/285053113_295.jpg" alt="Tomas Petricek on F# applications: From domain model to user interface" style="height: 120px;" />
+          </a>
+          <h4>Tomas Petricek on F# applications: From domain model to user interface</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/37477716">
+            <img src="http://b.vimeocdn.com/ts/257/487/257487624_295.jpg" alt="Coding F# (F-Sharp, English): Get Stock Quote Data and Historical Stock Prices" style="height: 120px;" />
+          </a>
+          <h4>Coding F# (F-Sharp, English): Get Stock Quote Data and Historical Stock Prices</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/46296644">
+            <img src="http://b.vimeocdn.com/ts/322/338/322338329_295.jpg" alt="Units of Measure in F#" style="height: 120px;" />
+          </a>
+          <h4>Units of Measure in F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/Charles/C9-Lectures-Donna-Malayeri-F-30-Information-Rich-Programming-1-of-1">
+            <img src="http://ak.channel9.msdn.com/ch9/8cea/cb25a821-adea-4ded-ae32-62bf4a118cea/FSharp3DonnaMalaYeri_220.jpg" alt="C9 Lectures: Donna Malayeri - F# 3.0 - Information Rich Programming, 1 of 1" style="height: 120px;" />
+          </a>
+          <h4>C9 Lectures: Donna Malayeri - F# 3.0 - Information Rich Programming, 1 of 1</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=4WxKFMb5i9Y">
+            <img src="http://i1.ytimg.com/vi/4WxKFMb5i9Y/mqdefault.jpg" alt="Let There Be Functional Programming with F#" style="height: 120px;" />
+          </a>
+          <h4>Let There Be Functional Programming with F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/39381728">
+            <img src="http://b.vimeocdn.com/ts/271/617/271617627_295.jpg" alt="Barb: How I built a simple dynamic programming language in F#" style="height: 120px;" />
+          </a>
+          <h4>Barb: How I built a simple dynamic programming language in F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/37477719">
+            <img src="http://b.vimeocdn.com/ts/257/484/257484586_295.jpg" alt="Coding with LINQ, Patterns &amp; Practices" style="height: 120px;" />
+          </a>
+          <h4>Coding with LINQ, Patterns &amp; Practices</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=GAPiihlizWQ">
+            <img src="http://i4.ytimg.com/vi/GAPiihlizWQ/mqdefault.jpg" alt="F# (F-Sharp) Tutorial - 3.3 - Reference Values [TutorialGenius.com]" style="height: 120px;" />
+          </a>
+          <h4>F# (F-Sharp) Tutorial - 3.3 - Reference Values [TutorialGenius.com]</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=OENr435_tuo">
+            <img src="http://i4.ytimg.com/vi/OENr435_tuo/mqdefault.jpg" alt="F# (F-Sharp) Tutorial - 2.4 - F-Sharp Interactive [TutorialGenius.com]" style="height: 120px;" />
+          </a>
+          <h4>F# (F-Sharp) Tutorial - 2.4 - F-Sharp Interactive [TutorialGenius.com]</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=6GWu09qHlpw">
+            <img src="http://i3.ytimg.com/vi/6GWu09qHlpw/mqdefault.jpg" alt="F# (F-Sharp) Tutorial - 4.1 - Conditional Expressions [TutorialGenius.com]" style="height: 120px;" />
+          </a>
+          <h4>F# (F-Sharp) Tutorial - 4.1 - Conditional Expressions [TutorialGenius.com]</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="pagination pagination-centered">
+    <ul>
+      <li>
+        <a href="2">«</a>
+      </li>
+      <li>
+        <a href="1">1</a>
+      </li>
+      <li>
+        <a href="2">2</a>
+      </li>
+      <li class="active">
+        <a href="3">3</a>
+      </li>
+      <li>
+        <a href="4">4</a>
+      </li>
+      <li>
+        <a href="5">5</a>
+      </li>
+      <li>
+        <a href="6">6</a>
+      </li>
+      <li>
+        <a href="7">7</a>
+      </li>
+      <li>
+        <a href="8">8</a>
+      </li>
+      <li>
+        <a href="9">9</a>
+      </li>
+      <li>
+        <a href="4">»</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/videos/4.md
+++ b/videos/4.md
@@ -4,8 +4,182 @@ title: F# Videos | Page 4
 headline: F# Talks, Tutorials and Podcasts
 ---
 
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=z49Wew284PE'><img src='http://i3.ytimg.com/vi/z49Wew284PE/mqdefault.jpg' alt='F# (F-Sharp) Tutorial - 4.4 - For Expressions [TutorialGenius.com]' style='height: 120px;'/></a><h4>F# (F-Sharp) Tutorial - 4.4 - For Expressions [TutorialGenius.com]</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=2_a9Rd53-jE'><img src='http://i3.ytimg.com/vi/2_a9Rd53-jE/mqdefault.jpg' alt='F# (F-Sharp) Tutorial - 3.1 - Values [TutorialGenius.com]' style='height: 120px;'/></a><h4>F# (F-Sharp) Tutorial - 3.1 - Values [TutorialGenius.com]</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=MDbnc0sGGjg'><img src='http://i2.ytimg.com/vi/MDbnc0sGGjg/mqdefault.jpg' alt='F# (F-Sharp) Tutorial - 3.4 - printfn [TutorialGenius.com]' style='height: 120px;'/></a><h4>F# (F-Sharp) Tutorial - 3.4 - printfn [TutorialGenius.com]</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/36629292'><img src='http://b.vimeocdn.com/ts/251/292/251292721_295.jpg' alt='High Performance F# in .NET and on the GPU with Jack Pappas [Part 2]' style='height: 120px;'/></a><h4>High Performance F# in .NET and on the GPU with Jack Pappas [Part 2]</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/46715794'><img src='http://b.vimeocdn.com/ts/325/420/325420713_295.jpg' alt='Building Single Page Web Applications with Pit FW and ServiceStack' style='height: 120px;'/></a><h4>Building Single Page Web Applications with Pit FW and ServiceStack</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/33699102'><img src='http://b.vimeocdn.com/ts/228/946/228946839_295.jpg' alt='High Performance F# in .NET and on the GPU with Jack Pappas' style='height: 120px;'/></a><h4>High Performance F# in .NET and on the GPU with Jack Pappas</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/46715923'><img src='http://b.vimeocdn.com/ts/325/429/325429389_295.jpg' alt='Experience report on FPish - Everything Functional' style='height: 120px;'/></a><h4>Experience report on FPish - Everything Functional</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/46303863'><img src='http://b.vimeocdn.com/ts/322/393/322393255_295.jpg' alt='F# Community Roundtable' style='height: 120px;'/></a><h4>F# Community Roundtable</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=-SGPEUuG1I8'><img src='http://i2.ytimg.com/vi/-SGPEUuG1I8/mqdefault.jpg' alt='F# 3.0' style='height: 120px;'/></a><h4>F# 3.0</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/posts/Tao-Liu-F-Design-Patterns'><img src='http://ak.channel9.msdn.com/ch9/4895/e65504a0-5d93-4a11-af72-9f78013d4895/TaoLiuFSharpDesignPatterns_220_ch9.jpg' alt='Tao Liu: F# Design Patterns' style='height: 120px;'/></a><h4>Tao Liu: F# Design Patterns</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/18517106'><img src='http://b.vimeocdn.com/ts/116/520/116520141_295.jpg' alt='FSharpRefactoring Highlight Usages' style='height: 120px;'/></a><h4>FSharpRefactoring Highlight Usages</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/30961156'><img src='http://b.vimeocdn.com/ts/208/308/208308090_295.jpg' alt='F# 3.0 Preview - Big Data in Little Syntax' style='height: 120px;'/></a><h4>F# 3.0 Preview - Big Data in Little Syntax</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/22416078'><img src='http://b.vimeocdn.com/ts/144/858/144858161_295.jpg' alt='SprinGraph Demo' style='height: 120px;'/></a><h4>SprinGraph Demo</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/28805698'><img src='http://b.vimeocdn.com/ts/192/447/192447644_295.jpg' alt='Design Patterns In F# with Steve Goguen' style='height: 120px;'/></a><h4>Design Patterns In F# with Steve Goguen</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/28803344'><img src='http://b.vimeocdn.com/ts/192/429/192429066_295.jpg' alt='An F# case study: fs-zmq with Paulmichael Blasucci' style='height: 120px;'/></a><h4>An F# case study: fs-zmq with Paulmichael Blasucci</h4></div></li></ul></div><div class='pagination pagination-centered'><ul><li><a href='3'>«</a></li><li><a href='1'>1<li><a href='2'>2<li><a href='3'>3<li class='active'><a href='4'>4<li><a href='5'>5<li><a href='6'>6<li><a href='7'>7<li><a href='8'>8<li><a href='9'>9<li><a href='5'>»</a></li></ul></div>
+<div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=z49Wew284PE">
+            <img src="http://i3.ytimg.com/vi/z49Wew284PE/mqdefault.jpg" alt="F# (F-Sharp) Tutorial - 4.4 - For Expressions [TutorialGenius.com]" style="height: 120px;" />
+          </a>
+          <h4>F# (F-Sharp) Tutorial - 4.4 - For Expressions [TutorialGenius.com]</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=2_a9Rd53-jE">
+            <img src="http://i3.ytimg.com/vi/2_a9Rd53-jE/mqdefault.jpg" alt="F# (F-Sharp) Tutorial - 3.1 - Values [TutorialGenius.com]" style="height: 120px;" />
+          </a>
+          <h4>F# (F-Sharp) Tutorial - 3.1 - Values [TutorialGenius.com]</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=MDbnc0sGGjg">
+            <img src="http://i2.ytimg.com/vi/MDbnc0sGGjg/mqdefault.jpg" alt="F# (F-Sharp) Tutorial - 3.4 - printfn [TutorialGenius.com]" style="height: 120px;" />
+          </a>
+          <h4>F# (F-Sharp) Tutorial - 3.4 - printfn [TutorialGenius.com]</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/36629292">
+            <img src="http://b.vimeocdn.com/ts/251/292/251292721_295.jpg" alt="High Performance F# in .NET and on the GPU with Jack Pappas [Part 2]" style="height: 120px;" />
+          </a>
+          <h4>High Performance F# in .NET and on the GPU with Jack Pappas [Part 2]</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/46715794">
+            <img src="http://b.vimeocdn.com/ts/325/420/325420713_295.jpg" alt="Building Single Page Web Applications with Pit FW and ServiceStack" style="height: 120px;" />
+          </a>
+          <h4>Building Single Page Web Applications with Pit FW and ServiceStack</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/33699102">
+            <img src="http://b.vimeocdn.com/ts/228/946/228946839_295.jpg" alt="High Performance F# in .NET and on the GPU with Jack Pappas" style="height: 120px;" />
+          </a>
+          <h4>High Performance F# in .NET and on the GPU with Jack Pappas</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/46715923">
+            <img src="http://b.vimeocdn.com/ts/325/429/325429389_295.jpg" alt="Experience report on FPish - Everything Functional" style="height: 120px;" />
+          </a>
+          <h4>Experience report on FPish - Everything Functional</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/46303863">
+            <img src="http://b.vimeocdn.com/ts/322/393/322393255_295.jpg" alt="F# Community Roundtable" style="height: 120px;" />
+          </a>
+          <h4>F# Community Roundtable</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=-SGPEUuG1I8">
+            <img src="http://i2.ytimg.com/vi/-SGPEUuG1I8/mqdefault.jpg" alt="F# 3.0" style="height: 120px;" />
+          </a>
+          <h4>F# 3.0</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/posts/Tao-Liu-F-Design-Patterns">
+            <img src="http://ak.channel9.msdn.com/ch9/4895/e65504a0-5d93-4a11-af72-9f78013d4895/TaoLiuFSharpDesignPatterns_220_ch9.jpg" alt="Tao Liu: F# Design Patterns" style="height: 120px;" />
+          </a>
+          <h4>Tao Liu: F# Design Patterns</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/18517106">
+            <img src="http://b.vimeocdn.com/ts/116/520/116520141_295.jpg" alt="FSharpRefactoring Highlight Usages" style="height: 120px;" />
+          </a>
+          <h4>FSharpRefactoring Highlight Usages</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/30961156">
+            <img src="http://b.vimeocdn.com/ts/208/308/208308090_295.jpg" alt="F# 3.0 Preview - Big Data in Little Syntax" style="height: 120px;" />
+          </a>
+          <h4>F# 3.0 Preview - Big Data in Little Syntax</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/22416078">
+            <img src="http://b.vimeocdn.com/ts/144/858/144858161_295.jpg" alt="SprinGraph Demo" style="height: 120px;" />
+          </a>
+          <h4>SprinGraph Demo</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/28805698">
+            <img src="http://b.vimeocdn.com/ts/192/447/192447644_295.jpg" alt="Design Patterns In F# with Steve Goguen" style="height: 120px;" />
+          </a>
+          <h4>Design Patterns In F# with Steve Goguen</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/28803344">
+            <img src="http://b.vimeocdn.com/ts/192/429/192429066_295.jpg" alt="An F# case study: fs-zmq with Paulmichael Blasucci" style="height: 120px;" />
+          </a>
+          <h4>An F# case study: fs-zmq with Paulmichael Blasucci</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="pagination pagination-centered">
+    <ul>
+      <li>
+        <a href="3">«</a>
+      </li>
+      <li>
+        <a href="1">1</a>
+      </li>
+      <li>
+        <a href="2">2</a>
+      </li>
+      <li>
+        <a href="3">3</a>
+      </li>
+      <li class="active">
+        <a href="4">4</a>
+      </li>
+      <li>
+        <a href="5">5</a>
+      </li>
+      <li>
+        <a href="6">6</a>
+      </li>
+      <li>
+        <a href="7">7</a>
+      </li>
+      <li>
+        <a href="8">8</a>
+      </li>
+      <li>
+        <a href="9">9</a>
+      </li>
+      <li>
+        <a href="5">»</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/videos/5.md
+++ b/videos/5.md
@@ -4,8 +4,182 @@ title: F# Videos | Page 5
 headline: F# Talks, Tutorials and Podcasts
 ---
 
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/46710752'><img src='http://b.vimeocdn.com/ts/325/387/325387120_295.jpg' alt='MonoRail 3.0 And F#' style='height: 120px;'/></a><h4>MonoRail 3.0 And F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/26696135'><img src='http://b.vimeocdn.com/ts/176/563/176563639_295.jpg' alt='Putting F# to Work for You with Keith Battocchi' style='height: 120px;'/></a><h4>Putting F# to Work for You with Keith Battocchi</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/25266066'><img src='http://b.vimeocdn.com/ts/166/249/166249180_295.jpg' alt='Getting your Functional on with F# and Chris Marinos' style='height: 120px;'/></a><h4>Getting your Functional on with F# and Chris Marinos</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/46302713'><img src='http://b.vimeocdn.com/ts/322/381/322381694_295.jpg' alt='Automating Acceptance Tests with F# and TickSpec' style='height: 120px;'/></a><h4>Automating Acceptance Tests with F# and TickSpec</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=5PdYmhS48NE'><img src='http://i2.ytimg.com/vi/5PdYmhS48NE/mqdefault.jpg' alt='Fsharp 3D visualization demo' style='height: 120px;'/></a><h4>Fsharp 3D visualization demo</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=rZ2AXFhnfoM'><img src='http://i3.ytimg.com/vi/rZ2AXFhnfoM/mqdefault.jpg' alt='FSharp Beginners I' style='height: 120px;'/></a><h4>FSharp Beginners I</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/25278085'><img src='http://b.vimeocdn.com/ts/166/343/166343763_295.jpg' alt='F# Today, F# Tomorrow with Don Syme' style='height: 120px;'/></a><h4>F# Today, F# Tomorrow with Don Syme</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=4YO7HD-UJPw'><img src='http://i1.ytimg.com/vi/4YO7HD-UJPw/mqdefault.jpg' alt='F# Tutorial: Windows Forms - NO CONSOLE -' style='height: 120px;'/></a><h4>F# Tutorial: Windows Forms - NO CONSOLE -</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/46300386'><img src='http://b.vimeocdn.com/ts/322/363/322363849_295.jpg' alt='F# In The Enterprise Panel' style='height: 120px;'/></a><h4>F# In The Enterprise Panel</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=tUuh_e_oQj4'><img src='http://i1.ytimg.com/vi/tUuh_e_oQj4/mqdefault.jpg' alt='C# + F# + XNA Shooting Game Prototype' style='height: 120px;'/></a><h4>C# + F# + XNA Shooting Game Prototype</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47218895'><img src='http://b.vimeocdn.com/ts/328/737/328737065_295.jpg' alt='Improving Productivity with Custom F# Application Templates and NuGet' style='height: 120px;'/></a><h4>Improving Productivity with Custom F# Application Templates and NuGet</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47219139'><img src='http://b.vimeocdn.com/ts/328/738/328738808_295.jpg' alt='Teaching F#: From numerical expressions to 3D graphics' style='height: 120px;'/></a><h4>Teaching F#: From numerical expressions to 3D graphics</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47219268'><img src='http://b.vimeocdn.com/ts/328/739/328739970_295.jpg' alt='Teaching Functional Programming to Young People' style='height: 120px;'/></a><h4>Teaching Functional Programming to Young People</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47219370'><img src='http://b.vimeocdn.com/ts/328/740/328740854_295.jpg' alt='Introducting WebSharper Sitelets' style='height: 120px;'/></a><h4>Introducting WebSharper Sitelets</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=TKvEHTomnsY'><img src='http://i1.ytimg.com/vi/TKvEHTomnsY/mqdefault.jpg' alt='F# Tutorial: Simple Console Calculator [Getting Started]' style='height: 120px;'/></a><h4>F# Tutorial: Simple Console Calculator [Getting Started]</h4></div></li></ul></div><div class='pagination pagination-centered'><ul><li><a href='4'>«</a></li><li><a href='1'>1<li><a href='2'>2<li><a href='3'>3<li><a href='4'>4<li class='active'><a href='5'>5<li><a href='6'>6<li><a href='7'>7<li><a href='8'>8<li><a href='9'>9<li><a href='6'>»</a></li></ul></div>
+<div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/46710752">
+            <img src="http://b.vimeocdn.com/ts/325/387/325387120_295.jpg" alt="MonoRail 3.0 And F#" style="height: 120px;" />
+          </a>
+          <h4>MonoRail 3.0 And F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/26696135">
+            <img src="http://b.vimeocdn.com/ts/176/563/176563639_295.jpg" alt="Putting F# to Work for You with Keith Battocchi" style="height: 120px;" />
+          </a>
+          <h4>Putting F# to Work for You with Keith Battocchi</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/25266066">
+            <img src="http://b.vimeocdn.com/ts/166/249/166249180_295.jpg" alt="Getting your Functional on with F# and Chris Marinos" style="height: 120px;" />
+          </a>
+          <h4>Getting your Functional on with F# and Chris Marinos</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/46302713">
+            <img src="http://b.vimeocdn.com/ts/322/381/322381694_295.jpg" alt="Automating Acceptance Tests with F# and TickSpec" style="height: 120px;" />
+          </a>
+          <h4>Automating Acceptance Tests with F# and TickSpec</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=5PdYmhS48NE">
+            <img src="http://i2.ytimg.com/vi/5PdYmhS48NE/mqdefault.jpg" alt="Fsharp 3D visualization demo" style="height: 120px;" />
+          </a>
+          <h4>Fsharp 3D visualization demo</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=rZ2AXFhnfoM">
+            <img src="http://i3.ytimg.com/vi/rZ2AXFhnfoM/mqdefault.jpg" alt="FSharp Beginners I" style="height: 120px;" />
+          </a>
+          <h4>FSharp Beginners I</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/25278085">
+            <img src="http://b.vimeocdn.com/ts/166/343/166343763_295.jpg" alt="F# Today, F# Tomorrow with Don Syme" style="height: 120px;" />
+          </a>
+          <h4>F# Today, F# Tomorrow with Don Syme</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=4YO7HD-UJPw">
+            <img src="http://i1.ytimg.com/vi/4YO7HD-UJPw/mqdefault.jpg" alt="F# Tutorial: Windows Forms - NO CONSOLE -" style="height: 120px;" />
+          </a>
+          <h4>F# Tutorial: Windows Forms - NO CONSOLE -</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/46300386">
+            <img src="http://b.vimeocdn.com/ts/322/363/322363849_295.jpg" alt="F# In The Enterprise Panel" style="height: 120px;" />
+          </a>
+          <h4>F# In The Enterprise Panel</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=tUuh_e_oQj4">
+            <img src="http://i1.ytimg.com/vi/tUuh_e_oQj4/mqdefault.jpg" alt="C# + F# + XNA Shooting Game Prototype" style="height: 120px;" />
+          </a>
+          <h4>C# + F# + XNA Shooting Game Prototype</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47218895">
+            <img src="http://b.vimeocdn.com/ts/328/737/328737065_295.jpg" alt="Improving Productivity with Custom F# Application Templates and NuGet" style="height: 120px;" />
+          </a>
+          <h4>Improving Productivity with Custom F# Application Templates and NuGet</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47219139">
+            <img src="http://b.vimeocdn.com/ts/328/738/328738808_295.jpg" alt="Teaching F#: From numerical expressions to 3D graphics" style="height: 120px;" />
+          </a>
+          <h4>Teaching F#: From numerical expressions to 3D graphics</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47219268">
+            <img src="http://b.vimeocdn.com/ts/328/739/328739970_295.jpg" alt="Teaching Functional Programming to Young People" style="height: 120px;" />
+          </a>
+          <h4>Teaching Functional Programming to Young People</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47219370">
+            <img src="http://b.vimeocdn.com/ts/328/740/328740854_295.jpg" alt="Introducting WebSharper Sitelets" style="height: 120px;" />
+          </a>
+          <h4>Introducting WebSharper Sitelets</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=TKvEHTomnsY">
+            <img src="http://i1.ytimg.com/vi/TKvEHTomnsY/mqdefault.jpg" alt="F# Tutorial: Simple Console Calculator [Getting Started]" style="height: 120px;" />
+          </a>
+          <h4>F# Tutorial: Simple Console Calculator [Getting Started]</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="pagination pagination-centered">
+    <ul>
+      <li>
+        <a href="4">«</a>
+      </li>
+      <li>
+        <a href="1">1</a>
+      </li>
+      <li>
+        <a href="2">2</a>
+      </li>
+      <li>
+        <a href="3">3</a>
+      </li>
+      <li>
+        <a href="4">4</a>
+      </li>
+      <li class="active">
+        <a href="5">5</a>
+      </li>
+      <li>
+        <a href="6">6</a>
+      </li>
+      <li>
+        <a href="7">7</a>
+      </li>
+      <li>
+        <a href="8">8</a>
+      </li>
+      <li>
+        <a href="9">9</a>
+      </li>
+      <li>
+        <a href="6">»</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/videos/6.md
+++ b/videos/6.md
@@ -4,8 +4,182 @@ title: F# Videos | Page 6
 headline: F# Talks, Tutorials and Podcasts
 ---
 
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=GhREMmKxNOk'><img src='http://i4.ytimg.com/vi/GhREMmKxNOk/mqdefault.jpg' alt='F# Tutorial: Create a Basic Program [Entry-Point Function]' style='height: 120px;'/></a><h4>F# Tutorial: Create a Basic Program [Entry-Point Function]</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47219455'><img src='http://b.vimeocdn.com/ts/328/741/328741167_295.jpg' alt='Trees, Language-Oriented Programming and F#' style='height: 120px;'/></a><h4>Trees, Language-Oriented Programming and F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/15563573'><img src='http://b.vimeocdn.com/ts/939/583/93958356_295.jpg' alt='Anton Tayanovskyy - Developing WebSharper 2.0 Applications' style='height: 120px;'/></a><h4>Anton Tayanovskyy - Developing WebSharper 2.0 Applications</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/14963006'><img src='http://b.vimeocdn.com/ts/893/318/89331823_295.jpg' alt='Scott Theleman - Understanding F# Workflows Part 2 of 2' style='height: 120px;'/></a><h4>Scott Theleman - Understanding F# Workflows Part 2 of 2</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/David+Gristwood/F-and-Windows-Azure-with-Don-Syme-3-of-4'><img src='http://ecn.channel9.msdn.com/o9/ch9/2aa7/37091a06-408a-40ae-b990-9df900b72aa7/fsharpanddon3_220_ch9.jpg' alt='F# and Windows Azure with Don Syme (#3 of 4)' style='height: 120px;'/></a><h4>F# and Windows Azure with Don Syme (#3 of 4)</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/David+Gristwood/An-F-Tutorial-with-Don-Syme-2-of-4'><img src='http://ecn.channel9.msdn.com/o9/ch9/1163/1fb6a177-e3f0-4f37-ba71-9df900b41163/fsharpanddon2_220_ch9.jpg' alt='An F# Tutorial with Don Syme (#2 of 4)' style='height: 120px;'/></a><h4>An F# Tutorial with Don Syme (#2 of 4)</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/David+Gristwood/An-Introduction-to-F-with-Don-Syme-1-of-4'><img src='http://ecn.channel9.msdn.com/o9/ch9/e797/cb868473-300d-4d62-aaea-9df900abe797/fsharpanddon1_220_ch9.jpg' alt='An Introduction to F# with Don Syme (#1 of 4)' style='height: 120px;'/></a><h4>An Introduction to F# with Don Syme (#1 of 4)</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/martinesmann/Teaching-programming-language-concepts-with-F-part-2'><img src='http://ecn.channel9.msdn.com/o9/ch9/0485/570485/PeterSestoftPart02_512_ch9.jpg' alt='Teaching programming language concepts with F#, part 2' style='height: 120px;'/></a><h4>Teaching programming language concepts with F#, part 2</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/martinesmann/Teaching-programming-language-concepts-with-F-part-1'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/570484_220x165.jpg' alt='Teaching programming language concepts with F#, part 1' style='height: 120px;'/></a><h4>Teaching programming language concepts with F#, part 1</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47219647'><img src='http://b.vimeocdn.com/ts/328/743/328743448_295.jpg' alt='A Thorough Introduction to WebSharper' style='height: 120px;'/></a><h4>A Thorough Introduction to WebSharper</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/Charles/Emerging-Langs-Clojure-and-F'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/563931_220x165.jpg' alt='ELC 2010: Rich Hickey and Joe Pamer - Perspectives on Clojure and F#' style='height: 120px;'/></a><h4>ELC 2010: Rich Hickey and Joe Pamer - Perspectives on Clojure and F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/14959931'><img src='http://b.vimeocdn.com/ts/893/077/89307721_295.jpg' alt='Understanding F# Workflows Part 1 of 2' style='height: 120px;'/></a><h4>Understanding F# Workflows Part 1 of 2</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47219713'><img src='http://b.vimeocdn.com/ts/328/751/328751680_295.jpg' alt='F# Templates, Patterns and Practices' style='height: 120px;'/></a><h4>F# Templates, Patterns and Practices</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47219924'><img src='http://b.vimeocdn.com/ts/328/745/328745394_295.jpg' alt='Introduction to Functional Programming' style='height: 120px;'/></a><h4>Introduction to Functional Programming</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Events/TechEd/NorthAmerica/2010/DEV307'><img src='http://i.msdn.microsoft.com/ff759495.mvs_150x113(en-us).jpg' alt='F# in Microsoft Visual Studio 2010' style='height: 120px;'/></a><h4>F# in Microsoft Visual Studio 2010</h4></div></li></ul></div><div class='pagination pagination-centered'><ul><li><a href='5'>«</a></li><li><a href='1'>1<li><a href='2'>2<li><a href='3'>3<li><a href='4'>4<li><a href='5'>5<li class='active'><a href='6'>6<li><a href='7'>7<li><a href='8'>8<li><a href='9'>9<li><a href='7'>»</a></li></ul></div>
+<div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=GhREMmKxNOk">
+            <img src="http://i4.ytimg.com/vi/GhREMmKxNOk/mqdefault.jpg" alt="F# Tutorial: Create a Basic Program [Entry-Point Function]" style="height: 120px;" />
+          </a>
+          <h4>F# Tutorial: Create a Basic Program [Entry-Point Function]</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47219455">
+            <img src="http://b.vimeocdn.com/ts/328/741/328741167_295.jpg" alt="Trees, Language-Oriented Programming and F#" style="height: 120px;" />
+          </a>
+          <h4>Trees, Language-Oriented Programming and F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/15563573">
+            <img src="http://b.vimeocdn.com/ts/939/583/93958356_295.jpg" alt="Anton Tayanovskyy - Developing WebSharper 2.0 Applications" style="height: 120px;" />
+          </a>
+          <h4>Anton Tayanovskyy - Developing WebSharper 2.0 Applications</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/14963006">
+            <img src="http://b.vimeocdn.com/ts/893/318/89331823_295.jpg" alt="Scott Theleman - Understanding F# Workflows Part 2 of 2" style="height: 120px;" />
+          </a>
+          <h4>Scott Theleman - Understanding F# Workflows Part 2 of 2</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/David+Gristwood/F-and-Windows-Azure-with-Don-Syme-3-of-4">
+            <img src="http://ecn.channel9.msdn.com/o9/ch9/2aa7/37091a06-408a-40ae-b990-9df900b72aa7/fsharpanddon3_220_ch9.jpg" alt="F# and Windows Azure with Don Syme (#3 of 4)" style="height: 120px;" />
+          </a>
+          <h4>F# and Windows Azure with Don Syme (#3 of 4)</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/David+Gristwood/An-F-Tutorial-with-Don-Syme-2-of-4">
+            <img src="http://ecn.channel9.msdn.com/o9/ch9/1163/1fb6a177-e3f0-4f37-ba71-9df900b41163/fsharpanddon2_220_ch9.jpg" alt="An F# Tutorial with Don Syme (#2 of 4)" style="height: 120px;" />
+          </a>
+          <h4>An F# Tutorial with Don Syme (#2 of 4)</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/David+Gristwood/An-Introduction-to-F-with-Don-Syme-1-of-4">
+            <img src="http://ecn.channel9.msdn.com/o9/ch9/e797/cb868473-300d-4d62-aaea-9df900abe797/fsharpanddon1_220_ch9.jpg" alt="An Introduction to F# with Don Syme (#1 of 4)" style="height: 120px;" />
+          </a>
+          <h4>An Introduction to F# with Don Syme (#1 of 4)</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/martinesmann/Teaching-programming-language-concepts-with-F-part-2">
+            <img src="http://ecn.channel9.msdn.com/o9/ch9/0485/570485/PeterSestoftPart02_512_ch9.jpg" alt="Teaching programming language concepts with F#, part 2" style="height: 120px;" />
+          </a>
+          <h4>Teaching programming language concepts with F#, part 2</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/martinesmann/Teaching-programming-language-concepts-with-F-part-1">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/570484_220x165.jpg" alt="Teaching programming language concepts with F#, part 1" style="height: 120px;" />
+          </a>
+          <h4>Teaching programming language concepts with F#, part 1</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47219647">
+            <img src="http://b.vimeocdn.com/ts/328/743/328743448_295.jpg" alt="A Thorough Introduction to WebSharper" style="height: 120px;" />
+          </a>
+          <h4>A Thorough Introduction to WebSharper</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/Charles/Emerging-Langs-Clojure-and-F">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/563931_220x165.jpg" alt="ELC 2010: Rich Hickey and Joe Pamer - Perspectives on Clojure and F#" style="height: 120px;" />
+          </a>
+          <h4>ELC 2010: Rich Hickey and Joe Pamer - Perspectives on Clojure and F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/14959931">
+            <img src="http://b.vimeocdn.com/ts/893/077/89307721_295.jpg" alt="Understanding F# Workflows Part 1 of 2" style="height: 120px;" />
+          </a>
+          <h4>Understanding F# Workflows Part 1 of 2</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47219713">
+            <img src="http://b.vimeocdn.com/ts/328/751/328751680_295.jpg" alt="F# Templates, Patterns and Practices" style="height: 120px;" />
+          </a>
+          <h4>F# Templates, Patterns and Practices</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47219924">
+            <img src="http://b.vimeocdn.com/ts/328/745/328745394_295.jpg" alt="Introduction to Functional Programming" style="height: 120px;" />
+          </a>
+          <h4>Introduction to Functional Programming</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Events/TechEd/NorthAmerica/2010/DEV307">
+            <img src="http://i.msdn.microsoft.com/ff759495.mvs_150x113(en-us).jpg" alt="F# in Microsoft Visual Studio 2010" style="height: 120px;" />
+          </a>
+          <h4>F# in Microsoft Visual Studio 2010</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="pagination pagination-centered">
+    <ul>
+      <li>
+        <a href="5">«</a>
+      </li>
+      <li>
+        <a href="1">1</a>
+      </li>
+      <li>
+        <a href="2">2</a>
+      </li>
+      <li>
+        <a href="3">3</a>
+      </li>
+      <li>
+        <a href="4">4</a>
+      </li>
+      <li>
+        <a href="5">5</a>
+      </li>
+      <li class="active">
+        <a href="6">6</a>
+      </li>
+      <li>
+        <a href="7">7</a>
+      </li>
+      <li>
+        <a href="8">8</a>
+      </li>
+      <li>
+        <a href="9">9</a>
+      </li>
+      <li>
+        <a href="7">»</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/videos/7.md
+++ b/videos/7.md
@@ -4,8 +4,182 @@ title: F# Videos | Page 7
 headline: F# Talks, Tutorials and Podcasts
 ---
 
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/13215304'><img src='http://b.vimeocdn.com/ts/754/907/75490747_295.jpg' alt='Steffen Forkmann on F# Open Source Tools' style='height: 120px;'/></a><h4>Steffen Forkmann on F# Open Source Tools</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/10745902'><img src='http://b.vimeocdn.com/ts/895/546/89554698_295.jpg' alt='F# and Silverlight' style='height: 120px;'/></a><h4>F# and Silverlight</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47220677'><img src='http://b.vimeocdn.com/ts/328/748/328748902_295.jpg' alt='Writing a Java to x86 Compiler in F#' style='height: 120px;'/></a><h4>Writing a Java to x86 Compiler in F#</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://msdn.microsoft.com/en-us/vstudio/ff681040'><img src='http://i.msdn.microsoft.com/ff681040.gf_150x113(en-us).jpg' alt='Getting started with F# in VS2010' style='height: 120px;'/></a><h4>Getting started with F# in VS2010</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://msdn.microsoft.com/en-us/vstudio/ff681044'><img src='http://i.msdn.microsoft.com/ff681044.ef_150x113(en-us).jpg' alt='Editing F# code in VS2010' style='height: 120px;'/></a><h4>Editing F# code in VS2010</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://msdn.microsoft.com/en-us/vstudio/ff681047'><img src='http://i.msdn.microsoft.com/ff681047.mf_150x113(en-us).jpg' alt='Managing F# projects in VS2010' style='height: 120px;'/></a><h4>Managing F# projects in VS2010</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://msdn.microsoft.com/en-us/vstudio/ff742849'><img src='http://i.msdn.microsoft.com/ff742849.vs2010_150x113(en-us).jpg' alt='Using the VS2010 Pro Power Tools Extension with F#' style='height: 120px;'/></a><h4>Using the VS2010 Pro Power Tools Extension with F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://msdn.microsoft.com/en-us/ee681481.aspx'><img src='http://i.msdn.microsoft.com/ff759495.flk_150x113(en-us).jpg' alt='Introduction to FSharp and the Let Keyword' style='height: 120px;'/></a><h4>Introduction to FSharp and the Let Keyword</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47220570'><img src='http://b.vimeocdn.com/ts/328/748/328748790_295.jpg' alt='F# for Testing and Analysis' style='height: 120px;'/></a><h4>F# for Testing and Analysis</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Series/C9-Lectures-Dr-Don-Syme-Introduction-to-F-/C9-Lectures-Dr-Don-Syme-Introduction-to-F-3-of-3'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/529500_220x165.jpg' alt='C9 Lectures: Dr. Don Syme - Introduction to F#, 3 of 3' style='height: 120px;'/></a><h4>C9 Lectures: Dr. Don Syme - Introduction to F#, 3 of 3</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Series/C9-Lectures-Dr-Don-Syme-Introduction-to-F-/C9-Lectures-Dr-Don-Syme-Introduction-to-F-2-of-3'><img src='http://ecn.channel9.msdn.com/o9/ch9/0/1/7/6/2/5/C9LecturesDonSymeFSharpP2_512_ch9.png' alt='C9 Lectures: Dr. Don Syme - Introduction to F#, 2 of 3' style='height: 120px;'/></a><h4>C9 Lectures: Dr. Don Syme - Introduction to F#, 2 of 3</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=YYQya5c5L-M'><img src='http://i2.ytimg.com/vi/YYQya5c5L-M/mqdefault.jpg' alt='F# for Visualization demo video' style='height: 120px;'/></a><h4>F# for Visualization demo video</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Series/C9-Lectures-Dr-Don-Syme-Introduction-to-F-/C9-Lectures-Dr-Don-Syme-Introduction-to-F-1-of-3'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/512054_220x165.jpg' alt='C9 Lectures: Dr. Don Syme - Introduction to F#, 1 of 3' style='height: 120px;'/></a><h4>C9 Lectures: Dr. Don Syme - Introduction to F#, 1 of 3</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47519741'><img src='http://b.vimeocdn.com/ts/329/623/329623965_295.jpg' alt='Open Source F# Tools' style='height: 120px;'/></a><h4>Open Source F# Tools</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/coding4fun/blog/Missile-Launchers-with-F'><img src='http://ecn.channel9.msdn.com/o9/c4f/images/9953075_220.jpg' alt='Missile Launchers with F#' style='height: 120px;'/></a><h4>Missile Launchers with F#</h4></div></li></ul></div><div class='pagination pagination-centered'><ul><li><a href='6'>«</a></li><li><a href='1'>1<li><a href='2'>2<li><a href='3'>3<li><a href='4'>4<li><a href='5'>5<li><a href='6'>6<li class='active'><a href='7'>7<li><a href='8'>8<li><a href='9'>9<li><a href='8'>»</a></li></ul></div>
+<div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/13215304">
+            <img src="http://b.vimeocdn.com/ts/754/907/75490747_295.jpg" alt="Steffen Forkmann on F# Open Source Tools" style="height: 120px;" />
+          </a>
+          <h4>Steffen Forkmann on F# Open Source Tools</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/10745902">
+            <img src="http://b.vimeocdn.com/ts/895/546/89554698_295.jpg" alt="F# and Silverlight" style="height: 120px;" />
+          </a>
+          <h4>F# and Silverlight</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47220677">
+            <img src="http://b.vimeocdn.com/ts/328/748/328748902_295.jpg" alt="Writing a Java to x86 Compiler in F#" style="height: 120px;" />
+          </a>
+          <h4>Writing a Java to x86 Compiler in F#</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://msdn.microsoft.com/en-us/vstudio/ff681040">
+            <img src="http://i.msdn.microsoft.com/ff681040.gf_150x113(en-us).jpg" alt="Getting started with F# in VS2010" style="height: 120px;" />
+          </a>
+          <h4>Getting started with F# in VS2010</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://msdn.microsoft.com/en-us/vstudio/ff681044">
+            <img src="http://i.msdn.microsoft.com/ff681044.ef_150x113(en-us).jpg" alt="Editing F# code in VS2010" style="height: 120px;" />
+          </a>
+          <h4>Editing F# code in VS2010</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://msdn.microsoft.com/en-us/vstudio/ff681047">
+            <img src="http://i.msdn.microsoft.com/ff681047.mf_150x113(en-us).jpg" alt="Managing F# projects in VS2010" style="height: 120px;" />
+          </a>
+          <h4>Managing F# projects in VS2010</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://msdn.microsoft.com/en-us/vstudio/ff742849">
+            <img src="http://i.msdn.microsoft.com/ff742849.vs2010_150x113(en-us).jpg" alt="Using the VS2010 Pro Power Tools Extension with F#" style="height: 120px;" />
+          </a>
+          <h4>Using the VS2010 Pro Power Tools Extension with F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://msdn.microsoft.com/en-us/ee681481.aspx">
+            <img src="http://i.msdn.microsoft.com/ff759495.flk_150x113(en-us).jpg" alt="Introduction to FSharp and the Let Keyword" style="height: 120px;" />
+          </a>
+          <h4>Introduction to FSharp and the Let Keyword</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47220570">
+            <img src="http://b.vimeocdn.com/ts/328/748/328748790_295.jpg" alt="F# for Testing and Analysis" style="height: 120px;" />
+          </a>
+          <h4>F# for Testing and Analysis</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Series/C9-Lectures-Dr-Don-Syme-Introduction-to-F-/C9-Lectures-Dr-Don-Syme-Introduction-to-F-3-of-3">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/529500_220x165.jpg" alt="C9 Lectures: Dr. Don Syme - Introduction to F#, 3 of 3" style="height: 120px;" />
+          </a>
+          <h4>C9 Lectures: Dr. Don Syme - Introduction to F#, 3 of 3</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Series/C9-Lectures-Dr-Don-Syme-Introduction-to-F-/C9-Lectures-Dr-Don-Syme-Introduction-to-F-2-of-3">
+            <img src="http://ecn.channel9.msdn.com/o9/ch9/0/1/7/6/2/5/C9LecturesDonSymeFSharpP2_512_ch9.png" alt="C9 Lectures: Dr. Don Syme - Introduction to F#, 2 of 3" style="height: 120px;" />
+          </a>
+          <h4>C9 Lectures: Dr. Don Syme - Introduction to F#, 2 of 3</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=YYQya5c5L-M">
+            <img src="http://i2.ytimg.com/vi/YYQya5c5L-M/mqdefault.jpg" alt="F# for Visualization demo video" style="height: 120px;" />
+          </a>
+          <h4>F# for Visualization demo video</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Series/C9-Lectures-Dr-Don-Syme-Introduction-to-F-/C9-Lectures-Dr-Don-Syme-Introduction-to-F-1-of-3">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/512054_220x165.jpg" alt="C9 Lectures: Dr. Don Syme - Introduction to F#, 1 of 3" style="height: 120px;" />
+          </a>
+          <h4>C9 Lectures: Dr. Don Syme - Introduction to F#, 1 of 3</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47519741">
+            <img src="http://b.vimeocdn.com/ts/329/623/329623965_295.jpg" alt="Open Source F# Tools" style="height: 120px;" />
+          </a>
+          <h4>Open Source F# Tools</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/coding4fun/blog/Missile-Launchers-with-F">
+            <img src="http://ecn.channel9.msdn.com/o9/c4f/images/9953075_220.jpg" alt="Missile Launchers with F#" style="height: 120px;" />
+          </a>
+          <h4>Missile Launchers with F#</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="pagination pagination-centered">
+    <ul>
+      <li>
+        <a href="6">«</a>
+      </li>
+      <li>
+        <a href="1">1</a>
+      </li>
+      <li>
+        <a href="2">2</a>
+      </li>
+      <li>
+        <a href="3">3</a>
+      </li>
+      <li>
+        <a href="4">4</a>
+      </li>
+      <li>
+        <a href="5">5</a>
+      </li>
+      <li>
+        <a href="6">6</a>
+      </li>
+      <li class="active">
+        <a href="7">7</a>
+      </li>
+      <li>
+        <a href="8">8</a>
+      </li>
+      <li>
+        <a href="9">9</a>
+      </li>
+      <li>
+        <a href="8">»</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/videos/8.md
+++ b/videos/8.md
@@ -4,8 +4,182 @@ title: F# Videos | Page 8
 headline: F# Talks, Tutorials and Podcasts
 ---
 
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/47521955'><img src='http://b.vimeocdn.com/ts/329/637/329637474_295.jpg' alt='Answering - Why would I want to use F#?' style='height: 120px;'/></a><h4>Answering - Why would I want to use F#?</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://vimeo.com/8493636'><img src='http://b.vimeocdn.com/ts/397/379/39737997_295.jpg' alt='F# Parallel and Concurrent Programming' style='height: 120px;'/></a><h4>F# Parallel and Concurrent Programming</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/kmcgrath/Lists-in-FSharp'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/505338_220x165.jpg' alt='Lists in F#' style='height: 120px;'/></a><h4>Lists in F#</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/kmcgrath/Discriminated-Unions-in-FSharp'><img src='http://ecn.channel9.msdn.com/o9/ch9/3/8/8/3/0/5/DiscriminatedUnions_512_ch9.png' alt='Discriminated Unions in F#' style='height: 120px;'/></a><h4>Discriminated Unions in F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/Charles/Andrew-Kennedy-F-Units-of-Measure'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/488754_220x165.jpg' alt='Andrew Kennedy: F# Units of Measure' style='height: 120px;'/></a><h4>Andrew Kennedy: F# Units of Measure</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/kmcgrath/Active-Patterns-F'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/477130_220x165.jpg' alt='Active Patterns (F#)' style='height: 120px;'/></a><h4>Active Patterns (F#)</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/kmcgrath/Patterns-and-Match-Expressions-in-F'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/477128_220x165.jpg' alt='Patterns and Match Expressions in F#' style='height: 120px;'/></a><h4>Patterns and Match Expressions in F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/matthijs/Taking-Efficiency-One-Step-Further-FSharp'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/472546_220x165.jpg' alt='Taking Efficiency One Step Further - F#' style='height: 120px;'/></a><h4>Taking Efficiency One Step Further - F#</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/kmcgrath/Creating-Your-First-FSharp-Program-with-Visual-Studio-2010'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/472134_220x165.jpg' alt='Creating Your First F# Program with Visual Studio 2010' style='height: 120px;'/></a><h4>Creating Your First F# Program with Visual Studio 2010</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/Charles/Luke-Hoban-Latest-version-of-F-Released-Whats-the-story-Whats-next'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/469468_220x165.jpg' alt='Luke Hoban: Latest version of F# Released - What&#39;s the story? What&#39;s next?' style='height: 120px;'/></a><h4>Luke Hoban: Latest version of F# Released - What&#39;s the story? What&#39;s next?</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/Charles/Jason-Olson-Composing-Programming-Languages-F-and-OO'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/466961_220x165.jpg' alt='Jason Olson: Composing Programming Languages, F# and OO' style='height: 120px;'/></a><h4>Jason Olson: Composing Programming Languages, F# and OO</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Shows/10-4/10-4-Episode-17-F-Intro'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/467545_220x165.jpg' alt='10-4 Episode 17: F# Intro' style='height: 120px;'/></a><h4>10-4 Episode 17: F# Intro</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=1qU7oWHvRKs'><img src='http://i2.ytimg.com/vi/1qU7oWHvRKs/mqdefault.jpg' alt='MSDN Webcast F# (1/6) | Deutsch' style='height: 120px;'/></a><h4>MSDN Webcast F# (1/6) | Deutsch</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=j9d_W_AD9Oc'><img src='http://i3.ytimg.com/vi/j9d_W_AD9Oc/mqdefault.jpg' alt='MSDN Webcast F# (3/6) | Deutsch' style='height: 120px;'/></a><h4>MSDN Webcast F# (3/6) | Deutsch</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=7dLsNswEeAY'><img src='http://i4.ytimg.com/vi/7dLsNswEeAY/mqdefault.jpg' alt='MSDN Webcast F# (4/6) | Deutsch' style='height: 120px;'/></a><h4>MSDN Webcast F# (4/6) | Deutsch</h4></div></li></ul></div><div class='pagination pagination-centered'><ul><li><a href='7'>«</a></li><li><a href='1'>1<li><a href='2'>2<li><a href='3'>3<li><a href='4'>4<li><a href='5'>5<li><a href='6'>6<li><a href='7'>7<li class='active'><a href='8'>8<li><a href='9'>9<li><a href='9'>»</a></li></ul></div>
+<div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/47521955">
+            <img src="http://b.vimeocdn.com/ts/329/637/329637474_295.jpg" alt="Answering - Why would I want to use F#?" style="height: 120px;" />
+          </a>
+          <h4>Answering - Why would I want to use F#?</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://vimeo.com/8493636">
+            <img src="http://b.vimeocdn.com/ts/397/379/39737997_295.jpg" alt="F# Parallel and Concurrent Programming" style="height: 120px;" />
+          </a>
+          <h4>F# Parallel and Concurrent Programming</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/kmcgrath/Lists-in-FSharp">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/505338_220x165.jpg" alt="Lists in F#" style="height: 120px;" />
+          </a>
+          <h4>Lists in F#</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/kmcgrath/Discriminated-Unions-in-FSharp">
+            <img src="http://ecn.channel9.msdn.com/o9/ch9/3/8/8/3/0/5/DiscriminatedUnions_512_ch9.png" alt="Discriminated Unions in F#" style="height: 120px;" />
+          </a>
+          <h4>Discriminated Unions in F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/Charles/Andrew-Kennedy-F-Units-of-Measure">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/488754_220x165.jpg" alt="Andrew Kennedy: F# Units of Measure" style="height: 120px;" />
+          </a>
+          <h4>Andrew Kennedy: F# Units of Measure</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/kmcgrath/Active-Patterns-F">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/477130_220x165.jpg" alt="Active Patterns (F#)" style="height: 120px;" />
+          </a>
+          <h4>Active Patterns (F#)</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/kmcgrath/Patterns-and-Match-Expressions-in-F">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/477128_220x165.jpg" alt="Patterns and Match Expressions in F#" style="height: 120px;" />
+          </a>
+          <h4>Patterns and Match Expressions in F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/matthijs/Taking-Efficiency-One-Step-Further-FSharp">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/472546_220x165.jpg" alt="Taking Efficiency One Step Further - F#" style="height: 120px;" />
+          </a>
+          <h4>Taking Efficiency One Step Further - F#</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/kmcgrath/Creating-Your-First-FSharp-Program-with-Visual-Studio-2010">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/472134_220x165.jpg" alt="Creating Your First F# Program with Visual Studio 2010" style="height: 120px;" />
+          </a>
+          <h4>Creating Your First F# Program with Visual Studio 2010</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/Charles/Luke-Hoban-Latest-version-of-F-Released-Whats-the-story-Whats-next">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/469468_220x165.jpg" alt="Luke Hoban: Latest version of F# Released - What's the story? What's next?" style="height: 120px;" />
+          </a>
+          <h4>Luke Hoban: Latest version of F# Released - What's the story? What's next?</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/Charles/Jason-Olson-Composing-Programming-Languages-F-and-OO">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/466961_220x165.jpg" alt="Jason Olson: Composing Programming Languages, F# and OO" style="height: 120px;" />
+          </a>
+          <h4>Jason Olson: Composing Programming Languages, F# and OO</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Shows/10-4/10-4-Episode-17-F-Intro">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/467545_220x165.jpg" alt="10-4 Episode 17: F# Intro" style="height: 120px;" />
+          </a>
+          <h4>10-4 Episode 17: F# Intro</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=1qU7oWHvRKs">
+            <img src="http://i2.ytimg.com/vi/1qU7oWHvRKs/mqdefault.jpg" alt="MSDN Webcast F# (1/6) | Deutsch" style="height: 120px;" />
+          </a>
+          <h4>MSDN Webcast F# (1/6) | Deutsch</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=j9d_W_AD9Oc">
+            <img src="http://i3.ytimg.com/vi/j9d_W_AD9Oc/mqdefault.jpg" alt="MSDN Webcast F# (3/6) | Deutsch" style="height: 120px;" />
+          </a>
+          <h4>MSDN Webcast F# (3/6) | Deutsch</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=7dLsNswEeAY">
+            <img src="http://i4.ytimg.com/vi/7dLsNswEeAY/mqdefault.jpg" alt="MSDN Webcast F# (4/6) | Deutsch" style="height: 120px;" />
+          </a>
+          <h4>MSDN Webcast F# (4/6) | Deutsch</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="pagination pagination-centered">
+    <ul>
+      <li>
+        <a href="7">«</a>
+      </li>
+      <li>
+        <a href="1">1</a>
+      </li>
+      <li>
+        <a href="2">2</a>
+      </li>
+      <li>
+        <a href="3">3</a>
+      </li>
+      <li>
+        <a href="4">4</a>
+      </li>
+      <li>
+        <a href="5">5</a>
+      </li>
+      <li>
+        <a href="6">6</a>
+      </li>
+      <li>
+        <a href="7">7</a>
+      </li>
+      <li class="active">
+        <a href="8">8</a>
+      </li>
+      <li>
+        <a href="9">9</a>
+      </li>
+      <li>
+        <a href="9">»</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/videos/9.md
+++ b/videos/9.md
@@ -4,6 +4,118 @@ title: F# Videos | Page 9
 headline: F# Talks, Tutorials and Podcasts
 ---
 
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.microsoftpdc.com/2009/FT20'><img src='http://i.msdn.microsoft.com/ff759495.pap_150x113(en-us).jpg' alt='F# for Parallel and Asynchronous Programming' style='height: 120px;'/></a><h4>F# for Parallel and Asynchronous Programming</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/martinesmann/Don-Syme-FSharp-and-functional-programming-in-NET'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/462983_220x165.jpg' alt='Don Syme: F# and functional programming in . NET' style='height: 120px;'/></a><h4>Don Syme: F# and functional programming in . NET</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/blogs/pdc2008/tl11'><img src='http://i.msdn.microsoft.com/ff759495.introduction_150x113(en-us).jpg' alt='An Introduction to Microsoft F#' style='height: 120px;'/></a><h4>An Introduction to Microsoft F#</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://www.youtube.com/watch?v=QIBSbNaw69U'><img src='http://i2.ytimg.com/vi/QIBSbNaw69U/mqdefault.jpg' alt='F#.NET Tutorial' style='height: 120px;'/></a><h4>F#.NET Tutorial</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/Charles/Don-Syme-Whats-new-in-F-Asynchronous-Workflows-and-welcome-to-the-NET-family'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/249559_220x165.jpg' alt='Don Syme: What&#39;s new in F# - Asynchronous Workflows (and welcome to the .NET family!)' style='height: 120px;'/></a><h4>Don Syme: What&#39;s new in F# - Asynchronous Workflows (and welcome to the .NET family!)</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/Charles/MSR-Cambridge-Tour-Machine-Learning-Group-Computer-Vision-and-F'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/231745_220x165.jpg' alt='MSR Cambridge Tour: Machine Learning Group, Computer Vision and F#' style='height: 120px;'/></a><h4>MSR Cambridge Tour: Machine Learning Group, Computer Vision and F#</h4></div></li></ul></div>
-<div class='row-fluid'><ul class='thumbnails'><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/Charles/Don-Syme-Introduction-to-F-Part-2'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/229608_220x165.jpg' alt='Don Syme: Introduction to F#, Part 2' style='height: 120px;'/></a><h4>Don Syme: Introduction to F#, Part 2</h4></div></li><li class='span4'><div class='thumbnail'; style='border: none;'><a href='http://channel9.msdn.com/Blogs/Charles/Don-Syme-Introduction-to-F-Part-1'><img src='http://ecn.channel9.msdn.com/o9/previewImages/220/229374_220x165.jpg' alt='Don Syme: Introduction to F#, Part 1' style='height: 120px;'/></a><h4>Don Syme: Introduction to F#, Part 1</h4></div></li></ul></div><div class='pagination pagination-centered'><ul><li><a href='8'>«</a></li><li><a href='1'>1<li><a href='2'>2<li><a href='3'>3<li><a href='4'>4<li><a href='5'>5<li><a href='6'>6<li><a href='7'>7<li><a href='8'>8<li class='active'><a href='9'>9<li class='disabled'><a href='#'>»</a></li></ul></div>
+<div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.microsoftpdc.com/2009/FT20">
+            <img src="http://i.msdn.microsoft.com/ff759495.pap_150x113(en-us).jpg" alt="F# for Parallel and Asynchronous Programming" style="height: 120px;" />
+          </a>
+          <h4>F# for Parallel and Asynchronous Programming</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/martinesmann/Don-Syme-FSharp-and-functional-programming-in-NET">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/462983_220x165.jpg" alt="Don Syme: F# and functional programming in . NET" style="height: 120px;" />
+          </a>
+          <h4>Don Syme: F# and functional programming in . NET</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/blogs/pdc2008/tl11">
+            <img src="http://i.msdn.microsoft.com/ff759495.introduction_150x113(en-us).jpg" alt="An Introduction to Microsoft F#" style="height: 120px;" />
+          </a>
+          <h4>An Introduction to Microsoft F#</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://www.youtube.com/watch?v=QIBSbNaw69U">
+            <img src="http://i2.ytimg.com/vi/QIBSbNaw69U/mqdefault.jpg" alt="F#.NET Tutorial" style="height: 120px;" />
+          </a>
+          <h4>F#.NET Tutorial</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/Charles/Don-Syme-Whats-new-in-F-Asynchronous-Workflows-and-welcome-to-the-NET-family">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/249559_220x165.jpg" alt="Don Syme: What's new in F# - Asynchronous Workflows (and welcome to the .NET family!)" style="height: 120px;" />
+          </a>
+          <h4>Don Syme: What's new in F# - Asynchronous Workflows (and welcome to the .NET family!)</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/Charles/MSR-Cambridge-Tour-Machine-Learning-Group-Computer-Vision-and-F">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/231745_220x165.jpg" alt="MSR Cambridge Tour: Machine Learning Group, Computer Vision and F#" style="height: 120px;" />
+          </a>
+          <h4>MSR Cambridge Tour: Machine Learning Group, Computer Vision and F#</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="row-fluid">
+    <ul class="thumbnails">
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/Charles/Don-Syme-Introduction-to-F-Part-2">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/229608_220x165.jpg" alt="Don Syme: Introduction to F#, Part 2" style="height: 120px;" />
+          </a>
+          <h4>Don Syme: Introduction to F#, Part 2</h4>
+        </div>
+      </li>
+      <li class="span4">
+        <div class="thumbnail" style="border: none;">
+          <a href="http://channel9.msdn.com/Blogs/Charles/Don-Syme-Introduction-to-F-Part-1">
+            <img src="http://ecn.channel9.msdn.com/o9/previewImages/220/229374_220x165.jpg" alt="Don Syme: Introduction to F#, Part 1" style="height: 120px;" />
+          </a>
+          <h4>Don Syme: Introduction to F#, Part 1</h4>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="pagination pagination-centered">
+    <ul>
+      <li>
+        <a href="8">«</a>
+      </li>
+      <li>
+        <a href="1">1</a>
+      </li>
+      <li>
+        <a href="2">2</a>
+      </li>
+      <li>
+        <a href="3">3</a>
+      </li>
+      <li>
+        <a href="4">4</a>
+      </li>
+      <li>
+        <a href="5">5</a>
+      </li>
+      <li>
+        <a href="6">6</a>
+      </li>
+      <li>
+        <a href="7">7</a>
+      </li>
+      <li>
+        <a href="8">8</a>
+      </li>
+      <li class="active">
+        <a href="9">9</a>
+      </li>
+      <li class="disabled">
+        <a href="#">»</a>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
Jekyll failed to parse the malformed HTML markup contained in the files of the previous pull request. The code is valid XML now.
