### PR TITLE
Add FreeBSD usage page to sitemap.

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -45,6 +45,10 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>http://fsharp.org/use/freebsd/index.html</loc>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>http://fsharp.org/use/android/index.html</loc>
     <priority>0.5</priority>
   </url>


### PR DESCRIPTION
Add the FreeBSD usage page to the sitemap (like the pages for Linux, Mac, etc.)
