### PR TITLE
Tweak powershell download code

### DIFF
--- a/use/windows/index.md
+++ b/use/windows/index.md
@@ -73,9 +73,9 @@ If you're just looking for a compiler and/or F# Interactive, e.g. for a build se
 
    Alternatively, do a quiet install from a PowerShell administrator prompt (the URL is the redirect of the above). 
 
-       $webclient = New-Object System.Net.WebClient
-       $url = "http://download.microsoft.com/download/0/5/E/05E5C5E3-2A52-434F-A09E-C8150B987D09/VWD_FSharp.exe"
-       $webclient.DownloadFile($url, "VWD_FSharp.exe")
+       $webclient = New-Object Net.WebClient
+       $url = 'http://download.microsoft.com/download/0/5/E/05E5C5E3-2A52-434F-A09E-C8150B987D09/VWD_FSharp.exe'
+       $webclient.DownloadFile($url, "$pwd\VWD_FSharp.exe")
        .\VWD_FSharp.exe /install /quiet
 
 The compiler tools are installed at


### PR DESCRIPTION
2 changes for style, 1 for correctness.
- It's not required to specify the leading `System` part of a namespace
- Unless interpolation is being used, best practice to always use single quotes
- Powershell keeps track of working directory separately from .NET. To download to the current psh directory, need to specify `$pwd` in the download path.
