### PR TITLE
add History link to "F# on IRC" side bar navigation pointing to ircbrowse.net fsharp page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -99,7 +99,7 @@
                 <li><a onclick="javascript:pageTracker._trackPageview(‘/outbound/sidebar/stackoverflow-tags’);" href="http://stackoverflow.com/questions/tagged/f%23">Ask on StackOverflow</a></li>
                 <li><a onclick="javascript:pageTracker._trackPageview(‘/outbound/sidebar/codereview-tags’);" href="http://codereview.stackexchange.com/questions/tagged/f%23">F# Code Review</a></li>
                 <li><a onclick="javascript:pageTracker._trackPageview(‘/outbound/sidebar/twitter-conversations’);" href="http://twitter.com/#fsharp">F# on Twitter</a></li>
-                <li><a onclick="javascript:pageTracker._trackPageview(‘/outbound/sidebar/irc’);" href="http://webchat.freenode.net/?channels=%23%23fsharp">F# on IRC</a></li>
+                <li><a onclick="javascript:pageTracker._trackPageview(‘/outbound/sidebar/irc’);" href="http://webchat.freenode.net/?channels=%23%23fsharp">F# on IRC</a> (<a onclick="javascript:pageTracker._trackPageview(‘/outbound/sidebar/irchistory’);" href="http://ircbrowse.net/day/fsharp/today">History</a>)</li>
                 <li><a href="/groups/">Join user groups</a></li>
                 <li><a href="/consulting">F# consultancies</a></li>
               </ul>


### PR DESCRIPTION
I don't have jekyll configured but I tried the change by altering the page with developer tools, it seems to not alter the layout of the navigation menu/page.
