### PR TITLE
Add a link to Vulpes

### DIFF
--- a/community/projects/index.md
+++ b/community/projects/index.md
@@ -98,6 +98,8 @@ Contributions welcome!
 
 *  [The Python Type Provider for F# (experimental)](http://fsprojects.github.io/FSharp.Interop.PythonProvider/) - Python type provider for F#.
 
+*  [Vulpes] (https://github.com/SpiegelSoft/Vulpes) - A machine learning app using a deep belief network and connecting to the NVIDIA GPU unit using [Alea.cuBase] (http://blog.quantalea.net/).
+
 <br />
 
 ### Community Projects: Visualization Tools


### PR DESCRIPTION
Vulpes uses Alea.cuBase to access the GPU for machine learning using a deep belief net algorithm.
