### PR TITLE
Adding link to `Apps and Games` page from Side Bar at fsharp.org

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -96,6 +96,7 @@
                 <ul>
                     <li><a onclick="javascript:pageTracker._trackPageview(‘/outbound/sidebar/open-source-list’);" href="http://groups.google.com/group/fsharp-opensource">F# open forum</a></li>
                     <li><a href="/community/projects/">F# community projects</a></li>
+                    <li><a href="/apps-and-games/">F# apps and games</a></li>
                     <li><a onclick="javascript:pageTracker._tra=ckPageview(‘/outbound/sidebar/news-from-blogs’);" href="http://fpish.net/blogs/Some/1/f~23/0">F# blogs</a></li>
                     <li><a href="/videos/1">Watch F# videos</a></li>
                     <li><a onclick="javascript:pageTracker._trackPageview(‘/outbound/sidebar/codeplex-projects’);" href="https://github.com/fsharp/">GitHub</a> and <a href="http://www.codeplex.com/site/search?query=&sortBy=Relevance&tagName=%2cF%23%2c">CodePlex</a></li>


### PR DESCRIPTION
I just noticed there is scant linkage to the webpage we just changed - http://fsharp.org/apps-and-games/ . The only link I could find was on this page - http://fsharp.org/use/ios/

I think this page should be more prominently displayed, perhaps on the side-bar under `Contributing` below `F# Community Projects`. Here is a patch that does so (I think... you better test it first :))
