### PR TITLE
Changed groups to pull from fusion table

### DIFF
--- a/groups/index.html
+++ b/groups/index.html
@@ -7,134 +7,24 @@ headline: F# User Groups
 <div class="row">
     <div id="contentMain">
 
-        <iframe style="width: 100%; height: 350px" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="http://mapsengine.google.com/map/embed?mid=z1n_4ekQGQtU.kB1JHL5On8Go"></iframe>
+        <iframe style="width: 100%; height: 350px"  scrolling="no" frameborder="no" src="https://www.google.com/fusiontables/embedviz?q=select+col1+from+1uxrOzPuy9u3o-y3UptmNFsCwU9Rty8jgrtJG7eJs&amp;viz=MAP&amp;h=false&amp;lat=-12.768364271785447&amp;lng=-12.022964843750037&amp;t=1&amp;z=1&amp;l=col1&amp;y=2&amp;tmplt=2&amp;hml=ONE_COL_LAT_LNG"></iframe><br>
+        <!--
+        <iframe style="width: 100%; height: 350px" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=z1n_4ekQGQtU.kB1JHL5On8Go"></iframe>
+        -->
         <br />
-        <p>
-            Note that the place for meetings changes for many of the user groups, so always check the 
-       user group page for the most up-to-date information. View <a href="http://mapsengine.google.com/map/embed?mid=z1n_4ekQGQtU.kB1JHL5On8Go">F# User Groups</a> in a larger map.
-      If you are running an F# user group that is missing to the list, please 
-      <a href="https://github.com/fsharp/fsfoundation/blob/gh-pages/groups/index.html">edit this page</a>!
+        <p>View <a href="https://www.google.com/fusiontables/embedviz?q=select+col1+from+1uxrOzPuy9u3o-y3UptmNFsCwU9Rty8jgrtJG7eJs&viz=MAP&h=false&lat=-12.768364271785447&lng=-12.02296484375006&t=1&z=1&l=col1&y=2&tmplt=2&hml=ONE_COL_LAT_LNG">F# User Groups</a> in a larger map.</p>
+        <p>Note that the location of meetings frequently changes for many of the user groups, so always check the 
+       user group page for the most up-to-date information. 
+      If you are running an F# user group that is missing from this list, please <a href="/foundation.html#contact">Contact Us</a>.
         </p>
-        <div class="row">
+          <div class="row">
             <div class="col-md-6">
-                <h2>Worldwide</h2>
-                <h3>Community for F#</h3>
-                <p>Wherever you might be, Community for F# makes great F# content available to you, and provides resources so that you can organize your own local user group. We stream talks online, and make presentation recordings available. We also provide material that you can use in your own meetings, as well as advice on how to grow a dynamic local community.</p>
-                <p>Check out our website at <a href="http://www.c4fsharp.net">c4fsharp.net</a>, or find us on Twitter as <a href="https://twitter.com/c4fsharp">@c4fsharp</a> - and let us know how we can help!</p>
-
-                <h2>North America</h2>
-                <h3>The San Francisco Bay Area F# User Group</h3>
-                <p>SF# is a group of developers in the San Francisco Bay Area who have an interest in the F# programming language.  Novices and experts are both welcome.</p>
-                <p>For more information, <a href="http://www.meetup.com/sfsharp/">see the group page on meetup</a>.</p>
-
-                <h3>Detroit F# Meetup</h3>
-                <p>A group of developers in Motown who are interested in learning to use F# to write better code. We meet once a month.</p>
-                <p>For more information, check the <a href="http://www.meetup.com/Detroit-F-Meetup/">Detroit F# Meetup</a> page.</p>
-
-                <h3>Cleveland, Ohio F# SIG</h3>
-                <p>The Cleveland F# SIG gives programmers at all skill levels a monthly opportunity to learn about the language and how others are using it, improve their skills and share their knowledge in a relaxed, cooperative environment.</p>
-                <p>For more information, <a href="http://www.bennettadelson.com/AllEvents.aspx?sig=c763cbd9-74b4-e011-8e22-1cc1de7983eb">visit the group web site</a>.</p>
-
-                <h3>Houston F# User Group</h3>
-                <p>A group for developers in the Houston area with an interest in the F# programming language. Programmers of all skill levels and backgrounds are welcome.</p>
-                <p>For more information, <a href="http://www.meetup.com/Houston-FSharp-User-Group/">see the group page on meetup</a>.</p>
-
-                <h3>New England F# Users Group</h3>
-                <p>This group is for anyone interested in the F# programming language. We'll discuss a wide variety of topics related to programming with F#, and developers of all skill levels and backgrounds are welcome.</p>
-                <p>For more information, <a href="http://www.meetup.com/New-England-F-Users-Group/">see the group page on meetup</a>.</p>
-
-                <h3>Chicago F# Users</h3>
-                <p>The Chicago F# Users group is dedicated to the advancement of the F# language throughout the Chicago area. If you are curious (or skeptical) about the F# language, regardless of your level of expertise with it, you are welcome! We would like to meet regularly to present solutions to real world problems that can be addressed through the use of F#.</p>
-                <p>For more information, <a href="http://www.meetup.com/Chicago-F-Users/">see the group page on meetup</a>.</p>
-
-                <h3>New York City F# User Group</h3>
-                <p>A group for both learning functional programming and exploring the limits of the F# programming language. Programmers of all skill levels and backgrounds are welcome.</p>
-                <p>For more information, <a href="http://www.meetup.com/nyc-fsharp/">see the group page on meetup</a>.</p>
-
-                <h3>F# Seattle User Group</h3>
-                <p>A group for learning and promoting F# programming language. Programmers of all skill levels and backgrounds are welcome.</p>
-                <p>For more information, <a href="http://www.meetup.com/FSharpSeattle/">see the group page on meetup</a>.</p>
-
-                <h3>Functional Programming Phoenix Group</h3>
-                <p>Developer group for functional languages (F# and others) and functional programming paradigms</p>
-                <p>For more information, <a href="http://www.meetup.com/FuncPhx/">see the group page on meetup</a>.</p>
-
-                <h3>Washington D.C. F# Meetup</h3>
-                <p>This is an F# meetup group that meets in and around the DC area. The goal is to bring likeminded local F# enthusiasts together to learn, play, and explore the F# language and ecosystem. Programmers of all skill levels and backgrounds are welcome.</p>
-                <p>For more information, <a href="http://www.meetup.com/DC-fsharp/">see the group page on meetup</a>.</p>
-
-                <h3>Indianapolis Mobile Developers</h3>
-                <p>This is a group for anyone interested in mobile development with .NET &amp; Xamarin technologies. All skills levels are welcome. If you are a mobile C#/F# developer or a C#/F# developer interested in building mobile apps you are encouraged to join.</p>
-                <p>For more information, <a href="http://www.meetup.com/IndianapolisMobileDevelopers/">see the group page on meetup</a>.</p>
-
-                <h3>Austin F# Meetup</h3>
-                <p>This is a group for growing and building an F# community in Austin as well as the functional programming community in general. We welcome people from all backgrounds and all levels of expertise.</p>
-                <p>For more information, <a href="http://www.meetup.com/Austin-F-Meetup/">see the group page on meetup</a>.</p>
-            </div>
-            <div class="col-md-6">
-                <h2>Europe</h2>
-                <h3>Zurich F# Users</h3>
-                <p>Our goal is to promote the usage of the multi-paradigm programming language F# in Switzerland. IT experts who have a professional or personal interest are cordially invited to join the group. We speak German and English.</p>
-                <p>For more information, <a href="http://www.meetup.com/zurich-fsharp-users/">see the group page on meetup</a>.</p>
-
-                <h3>Functional Programming in F#</h3>
-                <p>Learn how to take advantage of F# and .NET platform to develop a real world functional programs If you are beginner or an expert in FP it doesn't matter. You are welcome!</p>
-                <p>For more information, <a href="http://www.meetup.com/Functional-Programming-in-F/">see the group page on meetup</a>.</p>
-
-                <h3>Minsk F# User Group</h3>
-                <p>This group is for everyone interested in functional programming and F# programming language.</p>
-                <p>For more information, <a href="http://www.meetup.com/fsharpminsk/">see the group page on meetup</a>.</p>
-
-                <h3>Athens F# User Group</h3>
-                <p>Our goal is to promote the usage of functional programming and especially F# (FSharp) in Greece.</p>
-                <p>For more information, <a href="http://www.meetup.com/Athens-FSharp/">see the group page on meetup</a>.</p>
-
-                <h3>The Greater Helsinki Area F# User Group</h3>
-                <p>This is a group of developers in the Greater Helsinki Area (Helsinki, Espoo, Vantaa, etc.), Finland, who have an interest in the F# programming language. Novices and experts are both welcome.</p>
-                <p>For more information, <a href="http://www.meetup.com/FSharpHelsinki/">see the group page on meetup</a>.</p>
-
-                <h3>Functional Programming Stockholm</h3>
-                <p>A user group focusing on functional programming in all of its forms. We meet at different locations in the beautiful city of Stockholm to discuss what we enjoy - functional programming.</p>
-                <p>For more information, <a href="https://groups.google.com/group/functional-programming-sthlm/about/">see the group mailing list</a>.</p>
-
-                <h3>F#unctional Londoners Meetup Group</h3>
-                <p>F#unctional Londoners is a meetup group that aims to bring together Londoners with an interest in functional programming with F#. </p>
-                <p>For more information, <a href="http://www.meetup.com/FSharpLondon/">see the group page on meetup</a>.</p>
-
-                <h3>F#unctional Copenhageners Meetup Group</h3>
-                <p>We mainly focus on F# and Haskell, but other functional programming languages are more than welcome.</p>
-                <p>For more information, <a href="http://www.meetup.com/MoedegruppeFunktionelleKoebenhavnere/">see the group page on meetup</a>.</p>
-
-                <h3>F# Milano</h3>
-                <p>Ciao! Questo gruppo è per chiunque sia interessato al linguaggio di programmazione F#, in zona Milano e dintorni. L'obiettivo è quello di imparare, giocare ed esplorare il linguaggio F# ed il suo ecosistema. Non importa se si conosca già F#, chiunque è benvenuto.</p>
-                <p>Ciao! This group is for anyone interested in the F# programming language in Italy ( meetings in Milan and surrounding area ). The goal is to learn, play and explore the F# language and its ecosystem. It does not matter if you dont know F#, anyone is welcome.</p>
-                <p>For more information, <a href="http://www.meetup.com/FSharp-Milano/">see the F# Milano group page on meetup</a>.</p>
-
-                <h3>Functional South Coast</h3>
-                <p>We're interested in functional programming - including F#; but will also be looking at a variety of other functional languages over the coming months. We plan to have speaker sessions and kata sessions.</p>
-                <p>For more information, <a href="http://www.meetup.com/Functional-South-Coast/">see the group page on meetup</a>.</p>
-
-                <h3>Functional Kats</h3>
-                <p>We meet up to solve problems with all possible functional languages, and we always have at least 1 F# solution; we also run practical workshops.</p>
-                <p>We are based in Dublin, Ireland. For more information, <a href="http://functionalkats.tumblr.com/">see the group website</a>.</p>
-
-                <h2>Asia</h2>
-                <h3>F# User Group Japan</h3>
-                <p>A user group for the F# programming language - a functional-first multi-paradigm programming language. </p>
-
-                <p>
-                    This community has been mainly a <a href="http://bit.ly/fsug-jp">virtual Google group</a>. Please 
-          register to get all important information and share your updates - be it up-to-date information, questions
-          or other topics related to F#.
-                </p>
-
-                <h3>F# User Group China</h3>
-                <p>A virtual user group for Chinese F# programmer. The community uses <a href="http://download.imqq.com/">QQ</a> to exchange F# programming ideas in real time. The QQ group number is 61436709, which can be found by following <a href="http://help.imqq.com/help_07_02/?s=7&q=2">the instructions</a>. Please join and share up-to-date information, questions, and tips related to F#.</p>
-
-                <h2>Australia</h2>
-                <h3>F# User Group Sydney</h3>
-                <p>A monthly user group for F# people living in Sydney. Please <a href="http://www.meetup.com/fsharp/">join our Meetup group</a> to be notified of our next meeting and to get involved.</p>
-            </div>
-        </div>
-    </div>
+            <h2>F# User Groups</h2>
+                <iframe width="100%" height="5750" scrolling="yes" frameBorder="0" src="https://www.google.com/fusiontables/embedviz?viz=CARD&amp;q=select+*+from+1uxrOzPuy9u3o-y3UptmNFsCwU9Rty8jgrtJG7eJs+where+col4+%3D+&#39;F%23+User+Group&#39;+order+by+col0+asc&amp;tmplt=3&amp;cpr=1"></iframe>
+             </div>
+             <div class="col-md-6">
+            <h2>F# Friendly User Groups</h2>    
+                <iframe width="100%" height="5750" scrolling="yes" frameBorder="0" src="https://www.google.com/fusiontables/embedviz?viz=CARD&amp;q=select+*+from+1uxrOzPuy9u3o-y3UptmNFsCwU9Rty8jgrtJG7eJs+where+col4+%3D+&#39;F%23+Friendly+Group&#39;+order+by+col0+asc&amp;tmplt=4&amp;cpr=1"></iframe>
+             </div>
+             </div>
 </div>


### PR DESCRIPTION
Groups contents and map are dynamically allocated from F# SF owned
google fusion table document, instead of being two separately maintained
lists.  See discussion with pros/cons in issue #242.
