### PR TITLE
Force site to use Kramdown (to remove page build warnings)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 safe: true
+encoding: utf-8
+markdown: kramdown


### PR DESCRIPTION
This appears to be completely safe.  Pages function properly when switched on a local repository.
For details, see: https://help.github.com/articles/migrating-your-pages-site-from-maruku
