### PR TITLE
Force site to use Kramdown (to remove page build warnings) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _site/
 *~
 .DS_Store
 run-jekyll.*
+Gemfile
+Gemfile.lock

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
 safe: true
+encoding: utf-8
+markdown: kramdown
 gems:
   - jekyll-redirect-from


### PR DESCRIPTION
Removes page build warnings by converting to kramdown from markdown in the configuration files.
