### PR TITLE
Added links to events and user groups

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -96,7 +96,8 @@
                 <ul>
                     <li><a href="http://groups.google.com/group/fsharp-opensource">F# open forum</a></li>
                     <li><a href="/community/projects/">F# community projects</a></li>
-                    <li><a href="/groups/">Join user groups</a></li>
+                    <li><a href="http://c4fsharp.net/groups.html">Join user groups</a></li>
+                    <li><a href="http://c4fsharp.net/events.html">Attend events</a></li>
                     <li><a href="http://twitter.com/#fsharp">F# on Twitter</a></li>
                     <li><a href="http://fpish.net/blogs/Some/1/f~23/0">F# blogs</a></li>
                     <li><a href="https://github.com/fsharp/">GitHub</a> and <a href="http://www.codeplex.com/site/search?query=&sortBy=Relevance&tagName=%2cF%23%2c">CodePlex</a></li>

--- a/groups/index.html
+++ b/groups/index.html
@@ -1,30 +1,10 @@
----
-layout: default
-title: F# User Groups | The F# Software Foundation
-headline: F# User Groups
----
-
-<div class="row">
-    <div id="contentMain">
-
-        <iframe style="width: 100%; height: 350px"  scrolling="no" frameborder="no" src="https://www.google.com/fusiontables/embedviz?q=select+col1+from+1uxrOzPuy9u3o-y3UptmNFsCwU9Rty8jgrtJG7eJs&amp;viz=MAP&amp;h=false&amp;lat=-12.768364271785447&amp;lng=-12.022964843750037&amp;t=1&amp;z=1&amp;l=col1&amp;y=2&amp;tmplt=2&amp;hml=ONE_COL_LAT_LNG"></iframe><br>
-        <!--
-        <iframe style="width: 100%; height: 350px" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=z1n_4ekQGQtU.kB1JHL5On8Go"></iframe>
-        -->
-        <br />
-        <p>View <a href="https://www.google.com/fusiontables/embedviz?q=select+col1+from+1uxrOzPuy9u3o-y3UptmNFsCwU9Rty8jgrtJG7eJs&viz=MAP&h=false&lat=-12.768364271785447&lng=-12.02296484375006&t=1&z=1&l=col1&y=2&tmplt=2&hml=ONE_COL_LAT_LNG">F# User Groups</a> in a larger map.</p>
-        <p>Note that the location of meetings frequently changes for many of the user groups, so always check the 
-       user group page for the most up-to-date information. 
-      If you are running an F# user group that is missing from this list, please <a href="/foundation.html#contact">Contact Us</a>.
-        </p>
-          <div class="row">
-            <div class="col-md-6">
-            <h2>F# User Groups</h2>
-                <iframe width="100%" height="5750" scrolling="yes" frameBorder="0" src="https://www.google.com/fusiontables/embedviz?viz=CARD&amp;q=select+*+from+1uxrOzPuy9u3o-y3UptmNFsCwU9Rty8jgrtJG7eJs+where+col4+%3D+&#39;F%23+User+Group&#39;+order+by+col0+asc&amp;tmplt=3&amp;cpr=1"></iframe>
-             </div>
-             <div class="col-md-6">
-            <h2>F# Friendly User Groups</h2>    
-                <iframe width="100%" height="5750" scrolling="yes" frameBorder="0" src="https://www.google.com/fusiontables/embedviz?viz=CARD&amp;q=select+*+from+1uxrOzPuy9u3o-y3UptmNFsCwU9Rty8jgrtJG7eJs+where+col4+%3D+&#39;F%23+Friendly+Group&#39;+order+by+col0+asc&amp;tmplt=4&amp;cpr=1"></iframe>
-             </div>
-             </div>
-</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta http-equiv="refresh" content="0; url=http://c4fsharp.net/groups.html">
+<link rel="canonical" href="http://c4fsharp.net/groups.html" />
+</head>
+<body>
+The current listing of all F# User groups has been moved to the <a href="http://c4fsharp.net/groups.html">Community for F#</a>.
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ headline: The F# Software Foundation
                         <li>Learn on <a href="http://tryfsharp.org/Learn">Try F#</a></li>
                         <li>Explore <a href="/about/learning.html">F# books and tutorials</a></li>
                         <li>Watch <a href="/videos/1">F# videos</a></li>
-                        <li>Find <a href="/groups">F# meetup groups</a></li>
+                        <li>Find <a href="http://c4fsharp.net/groups.html">F# user groups</a></li>
                     </ul>
                 </div>
             </div>
@@ -45,7 +45,7 @@ headline: The F# Software Foundation
                     <h4>Going Further with F#</h4>
                     <ul>
                         <li>Ask <a href="http://stackoverflow.com/tags/f%23/info">questions about F#</a></li>
-                        <li>Find <a href="/groups/">F# meetups</a></li>
+                        <li>Attend <a href="http://c4fsharp.net/events.html">F# events</a></li>
                         <li>Contribute to <a href="/community/projects/">F# projects</a></li>
                         <li>Gain skills with <a href="/training">F# trainings</a></li>
                         <li>Engage <a href="/consulting">F# consultants</a></li>


### PR DESCRIPTION
New pull request to handle discussion from previous pull request in #252.

This PR adds links to the live events page with a map now hosted on c4fsharp.net.  This also moves the groups to c4fsharp.net and updates all links accordingly.

As suggested by @dsyme, all data is now pulling from c4fsharp "owned" sources and hosted there.
