### PR TITLE
Added apt-get install automake

### DIFF
--- a/use/linux/index.md
+++ b/use/linux/index.md
@@ -46,7 +46,7 @@ go further.
 
 2. Build and install the F# Compiler (open edition) from source.
 
-        sudo apt-get install autoconf libtool pkg-config make git
+        sudo apt-get install autoconf libtool pkg-config make git automake
         git clone https://github.com/fsharp/fsharp
         cd fsharp
         ./autogen.sh --prefix /usr


### PR DESCRIPTION
automake seems to be needed to compile F#
