### PR TITLE
Added link for Visual Studio 2013 Tools for Unity

### DIFF
--- a/guides/apps-and-games/index.md
+++ b/guides/apps-and-games/index.md
@@ -111,6 +111,13 @@ support recent versions of Visual Studio.
 
 * [F# With XNA Game Studio](http://azerdark.wordpress.com/2011/04/05/f-with-xna-game-studio/)
 * [XNA Game Studio for Visual Studio 2013](https://msxna.codeplex.com/)
+
+
+### Unity3D
+
+[Visual Studio 2013 Tools for Unity](http://visualstudiogallery.msdn.microsoft.com/20b80b8c-659b-45ef-96c1-437828fe7cf2) allows you to write and debug your Unity 3D games inside Microsoft Visual Studio.
+With this plugin you can debug DLLs built with F# in Visual Studio while running them from Unity3D, however currently it does not support creating F# scripts directly inside of the Unity3D editor.
+
   
 ### Projects
 


### PR DESCRIPTION
Visual Studio 2013 Tools for Unity adds a build target to Visual Studio projects.  This allows you to build a DLL using F# and then debug it while running under Unity3D.
