### PR TITLE
Add AutoFixture.AutoFoq project to Testing Tools

### DIFF
--- a/community/projects/index.md
+++ b/community/projects/index.md
@@ -340,6 +340,8 @@ Contributions welcome!
 
 *  ![logo](/images/thumbs/Foq.png)&nbsp;[Foq](http://foq.codeplex.com/) - A lightweight thread-safe mocking library for F#, C# & VB.Net. Use Foq to mock abstract classes and interfaces.
 
+*  [AutoFixture.AutoFoq](http://www.nuget.org/packages/AutoFixture.AutoFoq) - A library which turns [AutoFixture](http://www.nuget.org/packages/AutoFixture) into an [Auto-mocking Container](http://blog.ploeh.dk/2013/03/11/auto-mocking-container/) where the mock instances are created by [Foq](https://github.com/fsprojects/Foq).
+
 *  ![logo](/images/thumbs/Unquote.png)&nbsp;[Unquote](https://code.google.com/p/unquote/) - F# unit test assertions as quoted expressions and step-by-step failure messages.
 
 *  ![logo](/images/thumbs/canopy.jpg)&nbsp;[canopy](http://lefthandedgoat.github.io/canopy/) - F#rictionless web testing with Selenium.


### PR DESCRIPTION
This pull request originates from [this](https://github.com/fsprojects/fsprojects.github.io/issues/5#issuecomment-62634180) comment – it adds [AutoFixture.AutoFoq](http://www.nuget.org/packages/AutoFixture.AutoFoq) to the Testing Tools section.

---

AutoFixture.AutoFoq turns [AutoFixture](http://www.nuget.org/packages/AutoFixture) into an [Auto-mocking Container](http://blog.ploeh.dk/2013/03/11/auto-mocking-container/) where the mock instances are created by [Foq](https://github.com/fsprojects/Foq).

**Typical usage**

In the test below the mocked instance is created automatically by Foq:

``` f#
[<Fact>]
let AutoMockInterfaceAndSetupExpectations() =
    // Fixture setup
    let fixture = Fixture().Customize(AutoFoqCustomization())
    let dummy = obj()
    // Exercise system
    let sut = fixture.Create<IInterface>()
    sut.MakeIt(dummy) |> ignore
    // Verify outcome
    Mock.Verify(<@ sut.MakeIt(dummy) @>, Times.Once)
    // Teardown
```

**Integration with xUnit.net**

The above test can be written declaratively using xUnit.net's data theories:

``` f#
[<Theory>][<AutoFoqData>]
let AutoMockInterfaceAndSetupExpectationsDeclaratively 
  (sut : IInterface, dummy : obj) =
    sut.MakeIt(dummy) |> ignore
    Mock.Verify(<@ sut.MakeIt(dummy) @>, Times.Once)
```

The `[AutoFoqData]` attribute is defined as:

``` f#
type AutoFoqDataAttribute() = 
    inherit AutoDataAttribute(
        Fixture().Customize(AutoFoqCustomization()))
```
