### PR TITLE
Fix #375

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -110,6 +110,61 @@ nav.affix {
     }
 }
 
+table {
+    width: 100%;
+    max-width: 100%;
+    margin-bottom: 20px;
+    border: 1px solid #ddd;
+}
+
+    table > thead > tr > th,
+    table > tbody > tr > th,
+    table > tfoot > tr > th,
+    table > thead > tr > td,
+    table > tbody > tr > td,
+    table > tfoot > tr > td {
+        padding: 8px;
+        line-height: 1.42857143;
+        vertical-align: top;
+        border-top: 1px solid #ddd;
+    }
+
+    table > thead > tr > th {
+        vertical-align: bottom;
+        border-bottom: 2px solid #ddd;
+    }
+
+    table > caption + thead > tr:first-child > th,
+    table > colgroup + thead > tr:first-child > th,
+    table > thead:first-child > tr:first-child > th,
+    table > caption + thead > tr:first-child > td,
+    table > colgroup + thead > tr:first-child > td,
+    table > thead:first-child > tr:first-child > td {
+        border-top: 0;
+    }
+
+    table > tbody + tbody {
+        border-top: 2px solid #ddd;
+    }
+
+    table > thead > tr > th,
+    table > tbody > tr > th,
+    table > tfoot > tr > th,
+    table > thead > tr > td,
+    table > tbody > tr > td,
+    table > tfoot > tr > td {
+        border: 1px solid #ddd;
+    }
+
+    table > thead > tr > th,
+    table > thead > tr > td {
+        border-bottom-width: 2px;
+    }
+
+    table > tbody > tr:nth-child(odd) {
+        background-color: #f9f9f9;
+    }
+
 /* Footer */
 
 html {


### PR DESCRIPTION
Bootstrap isolates table styles given its widespread use in plugins, I'll force them here since we're not using such plugins.
