### PR TITLE
Update Fable REPL urls

### DIFF
--- a/use/browser/index.md
+++ b/use/browser/index.md
@@ -11,9 +11,9 @@ computer. It includes example code for many of F#'s basic features.
 
 <br />
 
-### Option 2: [Try Fable in the REPL](https://fable.io/repl3/)
+### Option 2: [Try Fable in the REPL](https://fable.io/repl/)
 
-![logo](../../images/thumbs/fable.png)&nbsp;[Try Fable in the REPL](https://fable.io/repl3/). Fable is a compiler powered by Babel that makes F# a first-class citizen of the JavaScript ecosystem.
+![logo](../../images/thumbs/fable.png)&nbsp;[Try Fable in the REPL](https://fable.io/repl/). Fable is a compiler powered by Babel that makes F# a first-class citizen of the JavaScript ecosystem.
 
 <br />
 

--- a/use/web-apps/index.md
+++ b/use/web-apps/index.md
@@ -16,7 +16,7 @@ not only web apps but also [node.js](https://nodejs.org/en/), desktop with [Elec
 or mobile with [React native](https://facebook.github.io/react-native/).
 
 * [Getting Started](https://fable.io/docs/2-steps/setup.html)
-* [Try Online](http://fable.io/repl3)
+* [Try Online](http://fable.io/repl)
 * [Docs](http://fable.io/docs/)
 
 <br />


### PR DESCRIPTION
The version of the REPL at `/repl3` no longer works.