### PR TITLE
Migrate unpkg links to jsdelivr

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -43,11 +43,10 @@
             );
     </script>
 
-    <script src="//unpkg.com/alpinejs" defer></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js"></script>
 
-    <script src="https://unpkg.com/htmx.org"></script>
-    <script src="https://unpkg.com/htmx.org@1.9.12/dist/ext/client-side-templates.js"></script>
-    <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx.org"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lunr/lunr.js"></script>
 
     
 


### PR DESCRIPTION
Unpkg is down and seems to have been having trouble for several hours now.

Unfortunately I used unpkg links for some libraries I added recently.

This PR migrates those links to jsdelvr as an interim fix until I can host those libs on the site.