### PR TITLE
Code snippet carousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,53 @@
 
 This repository hosts [The F# Software Foundation web site](https://fsharp.org/). Pull requests are welcome. The web site code is hosted in the `gh-pages` branch and is created using the tools provided by GitHub:
 
+* Fork this repository
 * Switch to [the `gh-pages` branch](https://github.com/fsharp/fsharp.org/tree/gh-pages)
-* Read [documentation for Github Pages](https://help.github.com/categories/20/articles)
 * The site is using [Jekyll for templating](http://jekyllrb.com/docs/usage/)
 
-## Development
+## Editing content
 
-The easiest way to get started with this repository is by using the supplied dev container.
+Most edits can be made by simply editing the appropriate markdown file. If you prefer to make your edit directly within github, there is a github actions which should build your fork automatically so you can confirm your changes look okay.
+
+## Testimonials
+
+New testimonials are very welcome!
+
+Simply add a new markdown file to the `_testimonials` folder. Take a look at the existing testimonials for the correct formatting and YAML frontmatter.
+
+## Code snippet/examples
+
+The code examples in the "code snippet carousel" are kept as individual markdown files in the `_snippets` folder. Please check the structure of existing snippets if you'd like to add a new one.
+
+The "code content" is in the YAML frontmatter and requires the "literal scalar block style", i.e. start with a `|` character, and indent the code block by four spaces.
+
+Note also the use of an excerpt separator `<!--more-->`. This is to ensure that only the content above that separator will appear on mobile (due to space constraints).
+
+Example:
+
+    ---
+    order: 0
+    title: HelloWorld.fs
+    excerpt_separator: <!--more-->
+    code: |
+        let hello name =
+            printfn $"Hello, {name}!"
+        
+        hello "github"
+    ---
+    ## I am the title
+
+    I am the introdoctory paragraph. Mobile and desktop users can see me.
+    <!--more-->
+    - **Desktop users** can see this extra content
+    - **Mobile users** will miss out
+    
+    Not ideal, but oh well.
+
+
+## Developing locally
+
+The easiest way to get started developing this repository on your own machine is by using the supplied dev container.
 
 ### Using the Dev Container
 
@@ -20,6 +60,12 @@ The easiest way to get started with this repository is by using the supplied dev
 A dev container is a pre-configured development environment that includes all the necessary tools and dependencies. It allows you to start developing without having to manually set up your environment.
 
 If not using VSCode, consult your preferred IDE's documentation for instructions.
+
+You may need to run the following once to install TailwindCSS dependency:
+
+```
+npm i
+```
 
 To start the development server, run the following command:
 

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,10 @@ collections:
   testimonials:
     output: false
     permalink: /testimonials/#:id
+  snippets:
+    output: false
+    sort_by: order
+    excerpt_enabled: false
     
 
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -70,7 +70,7 @@
                             <a href="{{ '/teaching/research' | relative_url }}" role="menuitem" class="group"
                                 tabindex="-1">Publications</a>
                             <a href="https://www.youtube.com/c/fsharporg" role="menuitem" class="group"
-                                tabindex="-1">Videos (FSFF channel)</a>
+                                tabindex="-1">Videos (FSSF channel)</a>
                             <a href="https://www.youtube.com/results?search_query=learn+f%23" role="menuitem"
                                 class="group" tabindex="-1">Videos (Community)</a>
                         </div>

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -25,15 +25,26 @@
     <meta name="msapplication-TileColor" content="#2d3947">
     <meta name="msapplication-TileImage" content="/mstile-144x144.png"> 
 
+    <!-- fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Roboto+Flex:opsz,wght@8..144,100..1000&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Roboto+Flex:opsz,wght@8..144,100..1000&display=swap" rel="stylesheet">
 
+    <!-- icons -->
     <link href="{{ '/css/fontawesome6/css/fontawesome.css' | relative_url }}" rel="stylesheet" />
     <link rel="stylesheet" href="{{ '/css/fontawesome6/css/brands.min.css' | relative_url }}"" />
     <link rel="stylesheet" href="{{ '/css/fontawesome6/css/solid.min.css' | relative_url }}" />
 
+    <!-- Swiper -->
+    <script src="
+    https://cdn.jsdelivr.net/npm/swiper@11.2.5/swiper-bundle.min.js
+    "></script>
+    <link href="
+    https://cdn.jsdelivr.net/npm/swiper@11.2.5/swiper-bundle.min.css
+    " rel="stylesheet">
+
     <link rel="stylesheet" href="{{ '/css/site.css' | relative_url }}" media="screen" />
+    <link rel="stylesheet" href="{{ '/css/monokai.css' | relative_url }}" media="screen" />
 
     <script>
         document.documentElement.classList.toggle(

--- a/_snippets/aoc_day1.md
+++ b/_snippets/aoc_day1.md
@@ -1,0 +1,34 @@
+---
+order: 16
+title: AOC_Day1.fs
+excerpt_separator: <!--more-->
+code: |
+    type Direction = Up | Down
+            
+    let parseDirections chars =
+        let parseDirection = function
+            | '(' -> Up
+            | ')' -> Down
+            | _ -> failwith "Invalid character!"
+        chars |> Seq.map parseDirection
+
+    let nextFloor currentFloor direction =
+        match direction with
+        | Up -> currentFloor + 1
+        | Down -> currentFloor - 1
+
+    let findEndingFloor startingFloor directions =
+        directions |> Seq.fold nextFloor startingFloor
+
+    "()(()((()((" |> parseChars |> findEndingFloor 0 |> printf
+---
+## Solve the Important Problems
+
+F# excels at solving algorithmic challenges with clarity and precision. The code elegantly tracks an elevator's movement through a building by parsing directional instructions.
+<!--more-->
+- **Discriminated unions** to model directions clearly
+- **Pattern matching** for expressive, exhaustive handling of cases  
+- **Higher-order functions** like `fold` to accumulate state
+- **Function composition** with the pipeline operator for readable data flow
+
+Notice how the solution reads almost like a plain English description of the problem, making it both maintainable and self-documenting.

--- a/_snippets/computation_expressions.md
+++ b/_snippets/computation_expressions.md
@@ -1,0 +1,76 @@
+---
+order: 17
+title: ComputationExpressions.fs
+excerpt_separator: <!--more-->
+code: |
+    // Sequence generation
+    let rec fizzBuzzSeq n =
+        seq {
+            yield
+                match n with
+                | x when x % 15 = 0 -> "fizzbuzz"
+                | x when x % 3 = 0 -> "fizz"
+                | x when x % 5 = 0 -> "buzz"
+                | _ -> n.ToString()
+
+            yield! fizzBuzzSeq (n + 1)
+        }
+
+    fizzBuzzSeq 1 |> Seq.take 100 |> Seq.iter (printfn "%s")
+
+    // Asynchronous programming with computation expressions
+    let fetchDataAsync url = async {
+        printfn "Fetching data from %s..." url
+        do! Async.Sleep 1000 // Simulate network delay
+        return sprintf "Data from %s" url
+    }
+
+    // Custom computation expression for validation
+    type ValidationBuilder() =
+        member _.Bind(x, f) = 
+            match x with
+            | Ok value -> f value
+            | Error e -> Error e
+        member _.Return(x) = Ok x
+        member _.ReturnFrom(x) = x
+
+    let validate = ValidationBuilder()
+
+    type Person = { Name: string; Age: int }
+
+    // Using our custom computation expression
+    let validatePerson age name = validate {
+        let! validAge = 
+            if age >= 0 && age < 150 then Ok age
+            else Error "Age must be between 0 and 150"
+            
+        let! validName = 
+            if String.length name > 0 then Ok name
+            else Error "Name cannot be empty"
+            
+        return { Name = validName; Age = validAge }
+    }
+
+    // Using multiple computation expressions together
+    let processPersonAsync person = async {
+        let result = validatePerson person.Age person.Name
+        match result with
+        | Ok validated ->
+            return! fetchDataAsync $"profile/{validated.Name}"
+        | Error msg ->
+            return $"Validation error: {msg}"
+    }
+
+    processPersonAsync { Name = "Snowdrop"; Age = 13}
+    |> Async.RunSynchronously
+---
+## Expressive Control Flow with Computation Expressions
+
+F# computation expressions provide an elegant syntax for complex control flows with a clean, readable notation that some say is F#'s superpower.
+<!--more-->
+- **Simplified asynchronous code** makes non-blocking operations read like synchronous code
+- **Custom control flow abstractions** create domain-specific mini-languages
+- **Seamless error handling** with [railway-oriented programming](https://fsharpforfunandprofit.com/rop/) patterns
+- **Elegant data transformations** by hiding boilerplate and focusing on business logic
+- **Composable workflows** that can be combined and nested for complex operations
+

--- a/_snippets/domain_modelling.md
+++ b/_snippets/domain_modelling.md
@@ -1,0 +1,45 @@
+---
+order: 15
+title: PaymentSystem.fs
+code: |
+    type CardInfo = { Number: string; Expiry: string; Cvv: string }
+    type BankInfo = { AccountNumber: string; RoutingNumber: string }
+    type PayPalInfo = { Email: string; Token: string }
+    
+    type PaymentMethod =
+        | CreditCard of CardInfo
+        | BankTransfer of BankInfo
+        | PayPal of PayPalInfo
+    
+    type Payment = {
+        Amount: decimal
+        Method: PaymentMethod
+    }
+    
+    let processPayment payment =
+        match payment.Method with
+        | CreditCard card -> 
+            printfn
+                "Processing $%.2f via card %s"
+                payment.Amount
+                card.Number
+        | BankTransfer bank ->
+            printfn
+                "Processing $%.2f via bank account %s"
+                payment.Amount
+                bank.AccountNumber
+        | PayPal pp ->
+            printfn
+                "Processing $%.2f via PayPal account %s"
+                payment.Amount
+                pp.Email
+---
+## Making Invalid States Unrepresentable
+This example showcases F#'s ability to create precise domain models that prevent errors at compile time.
+
+- **Discriminated unions** model each payment method with exactly the fields it needs
+- **No "impossible" states** can exist - a credit card payment can't have a routing number
+- **Exhaustive pattern matching** ensures every payment type is handled properly
+- **Type safety** catches errors at compile time that would be runtime bugs in other languages
+
+By modeling your domain using F#'s algebraic data types, you create self-documenting code where the type system itself enforces business rules. This powerful technique shifts many bugs from runtime to compile time, dramatically improving software reliability.

--- a/_snippets/fable.md
+++ b/_snippets/fable.md
@@ -1,0 +1,42 @@
+---
+order: 12
+title: FableJS.fs
+excerpt_separator: <!--more-->
+code: |
+    open Browser.Dom
+    open Feliz
+    
+    // DOM manipulation
+    let button = document.createElement("button")
+    button.textContent <- "Click me!"
+    button.addEventListener("click", fun _ -> 
+        window.alert("Hello from F#!")
+    )
+    document.body.appendChild(button) |> ignore
+
+    // React component (Feliz)
+    let counter = React.functionComponent(fun () ->
+        let (count, setCount) = React.useState(0)
+        Html.div [
+            Html.button [
+                prop.text "-"
+                prop.onClick (fun _ -> setCount(count - 1) )
+            ]
+            Html.span [prop.text count]
+            Html.button [
+                prop.text "+"
+                prop.onClick (fun _ -> setCount(count + 1) )
+            ]
+        ]
+    )
+---
+## F# for JavaScript Development
+
+F# isn't just for .NET development - with [Fable](https://fable.io/), it becomes a powerful language for JavaScript environments.
+<!--more-->
+- **Type-safe DOM manipulation** catches errors at compile time, not runtime
+- **Seamless React integration** with hooks and modern patterns
+- **Full npm ecosystem access** with clean TypeScript-like interop
+- **Simplified async programming** with F#'s computation expressions for promises
+
+Fable brings F#'s powerful type system and immutability to frontend development, eliminating common JavaScript bugs while maintaining full access to the JavaScript ecosystem.

--- a/_snippets/fable.md
+++ b/_snippets/fable.md
@@ -1,6 +1,6 @@
 ---
 order: 12
-title: FableJS.fs
+title: WebApps.fs
 excerpt_separator: <!--more-->
 code: |
     open Browser.Dom
@@ -32,11 +32,11 @@ code: |
 ---
 ## F# for JavaScript Development
 
-F# isn't just for .NET development - with [Fable](https://fable.io/), it becomes a powerful language for JavaScript environments.
+F# isn't just for .NET development - with [F# web technologies]({{ '/use/web-apps/' | relative_url }}), you can target JavaScript environments directly.
 <!--more-->
 - **Type-safe DOM manipulation** catches errors at compile time, not runtime
 - **Seamless React integration** with hooks and modern patterns
 - **Full npm ecosystem access** with clean TypeScript-like interop
 - **Simplified async programming** with F#'s computation expressions for promises
 
-Fable brings F#'s powerful type system and immutability to frontend development, eliminating common JavaScript bugs while maintaining full access to the JavaScript ecosystem.
+F# brings its powerful type system and immutability to frontend development, eliminating common JavaScript bugs while maintaining full access to the JavaScript ecosystem.

--- a/_snippets/helloworld.md
+++ b/_snippets/helloworld.md
@@ -18,7 +18,7 @@ code: |
     
     greets |> List.iter hello
 ---
-## Concise and Expressive Code
+## Concise and Expressive like Python
 
 This simple "Hello World" example demonstrates F#'s elegant syntax and functional approach to programming.
 <!--more-->

--- a/_snippets/helloworld.md
+++ b/_snippets/helloworld.md
@@ -1,0 +1,31 @@
+---
+order: 0
+title: HelloWorld.fs
+excerpt_separator: <!--more-->
+code: |
+    let hello name =
+        printfn $"Hello, {name}!"
+
+    let greets = [
+        "World"
+        "Solar System"
+        "Milky Way Galaxy"
+        "Local Galactic Group"
+        "Virgo Supercluster"
+        "Universe"
+        "Omniverse"
+    ]
+    
+    greets |> List.iter hello
+---
+## Concise and Expressive Code
+
+This simple "Hello World" example demonstrates F#'s elegant syntax and functional approach to programming.
+<!--more-->
+- **Concise function syntax** defines reusable functions with minimal boilerplate
+- **Clean list creation** uses indentation-based syntax without requiring commas
+- **String interpolation** provides readable string formatting with the `$` prefix
+- **Pipeline operator** creates a readable left-to-right flow of data
+- **Higher-order functions** allow applying operations across collections easily
+
+In just a few lines of code, F# provides a clean, readable implementation that would require significantly more boilerplate in many other languages. This expressive style becomes even more valuable as your programs grow in complexity.

--- a/_snippets/oop.md
+++ b/_snippets/oop.md
@@ -8,21 +8,23 @@ code: |
         abstract Add: x: int -> y: int -> int
         abstract Multiply: x: int -> y: int -> int
 
-    // Class implementation
-    type BasicCalculator() =
+    // Class implementation with interface
+    type Calculator(precision: int) =
+        // Private field using let binding
+        let mutable _precision = precision
+        
+        // Interface implementation
         interface ICalculator with
             member this.Add x y = x + y
             member this.Multiply x y = x * y
         
-        // Class method
+        // Public methods
         member this.Subtract(x, y) = x - y
         
-    // Class with constructor and property
-    type ScientificCalculator(precision: int) =
-        inherit BasicCalculator()
-        
-        // Auto-property with getter and setter
-        member val Precision = precision with get, set
+        // Property with explicit getter/setter
+        member this.Precision 
+            with get() = _precision
+            and set(value) = _precision <- value
         
         // Method using property
         member this.RoundToPrecision(value: float) =
@@ -46,20 +48,19 @@ code: |
                 member _.Multiply x y = x * y }
         
         // Class instantiation
-        let basic = BasicCalculator()
-        let scientific = ScientificCalculator(2)
+        let calc = Calculator(2)
         
-        printfn "5 + 3 = %d" (basic.Subtract(5, 3))
+        printfn "5 - 3 = %d" (calc.Subtract(5, 3))
         printfn "Is 10 even? %b" (10.IsEven)
-        printfn "2.345 rounded = %f" (scientific.RoundToPrecision(2.345))
-        printfn "2^3 = %f" (scientific.Power(2.0, 3.0))
+        printfn "2.345 rounded = %f" (calc.RoundToPrecision(2.345))
+        printfn "2^3 = %f" (calc.Power(2.0, 3.0))
 ---
-## Object Oriented Programming Support
+## Object Programming Made Simple
 
-F# is **functional first** and **immutable by default**, but it also provides full support for object-oriented programming.
+F# is **functional first** and **immutable by default**, but it also provides pragmatic support for object programming.
 <!--more-->
 - **Seamless .NET integration** lets you work with existing .NET libraries and frameworks
-- **Rich class system** allows you to build robust object hierarchies with interfaces and inheritance
+- **Rich interface system** allows you to define clear contracts for your components
 - **Object expressions** provide lightweight implementation of interfaces without defining full classes
 - **Concise member syntax** keeps methods and properties clean and readable
 - **Automatic property generation** reduces boilerplate code for data-carrying types

--- a/_snippets/oop.md
+++ b/_snippets/oop.md
@@ -1,0 +1,66 @@
+---
+order: 11
+title: OOP.fs
+excerpt_separator: <!--more-->
+code: |
+    // Interface definition
+    type ICalculator =
+        abstract Add: x: int -> y: int -> int
+        abstract Multiply: x: int -> y: int -> int
+
+    // Class implementation
+    type BasicCalculator() =
+        interface ICalculator with
+            member this.Add x y = x + y
+            member this.Multiply x y = x * y
+        
+        // Class method
+        member this.Subtract(x, y) = x - y
+        
+    // Class with constructor and property
+    type ScientificCalculator(precision: int) =
+        inherit BasicCalculator()
+        
+        // Auto-property with getter and setter
+        member val Precision = precision with get, set
+        
+        // Method using property
+        member this.RoundToPrecision(value: float) =
+            System.Math.Round(value, this.Precision)
+            
+        // Method with default parameter
+        member this.Power(x: float, ?exponent: float) =
+            let exp = defaultArg exponent 2.0
+            System.Math.Pow(x, exp)
+    
+    // Type extension - add method to existing type
+    type System.Int32 with
+        member this.IsEven = this % 2 = 0
+
+    // Demo usage
+    let demo() =
+        // Object expression (anonymous implementation)
+        let quickCalc = 
+            { new ICalculator with 
+                member _.Add x y = x + y
+                member _.Multiply x y = x * y }
+        
+        // Class instantiation
+        let basic = BasicCalculator()
+        let scientific = ScientificCalculator(2)
+        
+        printfn "5 + 3 = %d" (basic.Subtract(5, 3))
+        printfn "Is 10 even? %b" (10.IsEven)
+        printfn "2.345 rounded = %f" (scientific.RoundToPrecision(2.345))
+        printfn "2^3 = %f" (scientific.Power(2.0, 3.0))
+---
+## Object Oriented Programming Support
+
+F# is **functional first** and **immutable by default**, but it also provides full support for object-oriented programming.
+<!--more-->
+- **Seamless .NET integration** lets you work with existing .NET libraries and frameworks
+- **Rich class system** allows you to build robust object hierarchies with interfaces and inheritance
+- **Object expressions** provide lightweight implementation of interfaces without defining full classes
+- **Concise member syntax** keeps methods and properties clean and readable
+- **Automatic property generation** reduces boilerplate code for data-carrying types
+- **Type extensions** let you add methods to existing types without inheritance

--- a/_snippets/typeproviders.md
+++ b/_snippets/typeproviders.md
@@ -1,0 +1,25 @@
+---
+order: 14
+title: TypeProviders.fs
+excerpt_separator: <!--more-->
+code: |
+    open FSharp.Data
+
+    type PeopleDB = CsvProvider<"people.csv">
+
+    let printPeople () =
+        let people = PeopleDB.Load("people.csv") // this can be a URL
+
+        for person in people.Rows do
+            // access the csv fields with intellisense and type safety!
+            printfn $"Name: %s{person.Name}, Id: %i{person.Id}"
+---
+## Type-Safe Access to External Data
+
+F# Type Providers create a seamless bridge between your code and external data sources.
+<!--more-->
+- **Zero-friction data access** connects to CSV, JSON, XML, SQL, and more without manual mapping
+- **Static typing at compile time** prevents runtime errors when accessing external data
+- **Automatic schema discovery** creates F# types directly from sample data or schemas
+- **Full IDE integration** provides intellisense for external data sources
+- **Design-time capabilities** validate your code against live data sources before execution

--- a/_snippets/unitsOfMeasure.md
+++ b/_snippets/unitsOfMeasure.md
@@ -1,0 +1,30 @@
+---
+order: 1
+title: UnitsOfMeasure.fs
+excerpt_separator: <!--more-->
+code: |
+    [<Measure>] type m  // Meters
+    [<Measure>] type s  // Seconds
+    
+    // Acceleration due to gravity
+    let g = 9.81<m/s^2> 
+
+    // The return type is inferred as float<m>
+    let distance ( t: float<s> ) =
+        0.5 * g * t * t  
+    
+    let fallDuration = 2.0<s>
+    let fallDistance = distance fallDuration
+    printfn $"Distance fallen in {fallDuration}s is {fallDistance}m"
+---
+## Units of Measure
+
+F# offers compile-time unit safety without runtime overhead, enforcing correctness mathematically.
+<!--more-->
+- **Compile-time dimensional safety** catches errors before running, preventing scientific and engineering mistakes
+- **Domain-specific units** express quantities that directly reflect your problem space
+- **Automatic unit conversions** maintain type safety while handling complex calculations
+- **Seamless interoperability** works with normal numeric types when needed
+- **Custom unit definitions** let you create your own units and conversions with simple syntax
+
+

--- a/css/main.css
+++ b/css/main.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
@@ -8,6 +9,7 @@
     --color-brand-light: #30b9db;
     --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-heading: "Roboto Flex", sans-serif;
+    --font-mono: "JetBrains Mono", monospace;
 }
 
 
@@ -118,18 +120,16 @@ a[href^="https://fsharp.org"]::after {
     background-image: none;
 }
 
-
-.tilt-me {
-    transform: rotate(-30deg);
+.snippet {
+    scrollbar-color: #222222aa #666666aa
 }
-
 /* 
 .content-container p,
 .content-container li {
     max-width: 44em;
 } */
 
-   
+
 
 
 

--- a/css/main.css
+++ b/css/main.css
@@ -121,14 +121,11 @@ a[href^="https://fsharp.org"]::after {
 }
 
 .snippet {
-    scrollbar-color: #222222aa #666666aa
+    scrollbar-color: #222222aa #666666aa;
+    pre, code {
+        font-variant-ligatures: none;
+    }
 }
-/* 
-.content-container p,
-.content-container li {
-    max-width: 44em;
-} */
-
 
 
 

--- a/css/monokai.css
+++ b/css/monokai.css
@@ -1,0 +1,65 @@
+/* .highlight pre { background-color: #272822; } */
+/* .highlight .hll { background-color: #272822; } */
+.highlight .c { color: #75715e } /* Comment */
+.highlight .err { color: #960050; background-color: #1e0010 } /* Error */
+.highlight .k { color: #2c63fa } /* Keyword */
+.highlight .l { color: #ae81ff } /* Literal */
+.highlight .n { color: #f8f8f2 } /* Name */
+.highlight .o { color: #f92672 } /* Operator */
+.highlight .p { color: #f8f8f2 } /* Punctuation */
+.highlight .cm { color: #75715e } /* Comment.Multiline */
+.highlight .cp { color: #75715e } /* Comment.Preproc */
+.highlight .c1 { color: #75715e } /* Comment.Single */
+.highlight .cs { color: #75715e } /* Comment.Special */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .kc { color: #2c63fa } /* Keyword.Constant */
+.highlight .kd { color: #2c63fa } /* Keyword.Declaration */
+.highlight .kn { color: #f92672 } /* Keyword.Namespace */
+.highlight .kp { color: #2c63fa } /* Keyword.Pseudo */
+.highlight .kr { color: #2c63fa } /* Keyword.Reserved */
+.highlight .kt { color: #2c63fa } /* Keyword.Type */
+.highlight .ld { color: #378bba } /* Literal.Date */
+.highlight .m { color: #ae81ff } /* Literal.Number */
+.highlight .s { color: #378bba } /* Literal.String */
+.highlight .na { color: #00d9ff } /* Name.Attribute */
+.highlight .nb { color: #f8f8f2 } /* Name.Builtin */
+.highlight .nc { color: #00d9ff } /* Name.Class */
+.highlight .no { color: #2c63fa } /* Name.Constant */
+.highlight .nd { color: #00d9ff } /* Name.Decorator */
+.highlight .ni { color: #f8f8f2 } /* Name.Entity */
+.highlight .ne { color: #00d9ff } /* Name.Exception */
+.highlight .nf { color: #00d9ff } /* Name.Function */
+.highlight .nl { color: #f8f8f2 } /* Name.Label */
+.highlight .nn { color: #f8f8f2 } /* Name.Namespace */
+.highlight .nx { color: #00d9ff } /* Name.Other */
+.highlight .py { color: #f8f8f2 } /* Name.Property */
+.highlight .nt { color: #f92672 } /* Name.Tag */
+.highlight .nv { color: #f8f8f2 } /* Name.Variable */
+.highlight .ow { color: #f92672 } /* Operator.Word */
+.highlight .w { color: #f8f8f2 } /* Text.Whitespace */
+.highlight .mf { color: #ae81ff } /* Literal.Number.Float */
+.highlight .mh { color: #ae81ff } /* Literal.Number.Hex */
+.highlight .mi { color: #ae81ff } /* Literal.Number.Integer */
+.highlight .mo { color: #ae81ff } /* Literal.Number.Oct */
+.highlight .sb { color: #378bba } /* Literal.String.Backtick */
+.highlight .sc { color: #378bba } /* Literal.String.Char */
+.highlight .sd { color: #378bba } /* Literal.String.Doc */
+.highlight .s2 { color: #378bba } /* Literal.String.Double */
+.highlight .se { color: #ae81ff } /* Literal.String.Escape */
+.highlight .sh { color: #378bba } /* Literal.String.Heredoc */
+.highlight .si { color: #378bba } /* Literal.String.Interpol */
+.highlight .sx { color: #378bba } /* Literal.String.Other */
+.highlight .sr { color: #378bba } /* Literal.String.Regex */
+.highlight .s1 { color: #378bba } /* Literal.String.Single */
+.highlight .ss { color: #378bba } /* Literal.String.Symbol */
+.highlight .bp { color: #f8f8f2 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #f8f8f2 } /* Name.Variable.Class */
+.highlight .vg { color: #f8f8f2 } /* Name.Variable.Global */
+.highlight .vi { color: #f8f8f2 } /* Name.Variable.Instance */
+.highlight .il { color: #ae81ff } /* Literal.Number.Integer.Long */
+
+.highlight .gh { } /* Generic Heading & Diff Header */
+.highlight .gu { color: #75715e; } /* Generic.Subheading & Diff Unified/Comment? */
+.highlight .gd { color: #f92672; } /* Generic.Deleted & Diff Deleted */
+.highlight .gi { color: #00d9ff; } /* Generic.Inserted & Diff Inserted */

--- a/index.html
+++ b/index.html
@@ -30,16 +30,20 @@ keywords: F#, FSharp, F# Programming
                         
                     </div>
                 </div>
-                
+
+ 
 
             </div>
-
             
+                
 
         </div>
 
         
     </section>
+
+
+    
 
     <section class="home-section px-6 py-18 bg-white dark:bg-slate-800 shadow-lg z-20">
         
@@ -61,6 +65,77 @@ keywords: F#, FSharp, F# Programming
         </div>
     </section>
 
+    <section class="home-section px-6 pt-12 pb-12 from-brand-dark to-brand-light/50 bg-gradient-to-b text-sm">
+        <div class="featured max-w-6xl mx-auto">
+            
+            <div
+                x-data="{swiper: null}"
+                x-init="swiper = new Swiper($refs.container, {
+                    loop: true,
+                    slidesPerView: 1,
+                    spaceBetween: 32,
+                })"
+                class="relative  w-full"
+                >
+
+                <div class="swiper-container w-full h-fit overflow-clip" x-ref="container">
+                    <div class="swiper-wrapper ">
+                        <!-- code snippets -->
+                        {% for snippet in site.snippets %}
+                        <div class="swiper-slide">
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-12">
+                                <div class="relative border-gray-950 border bg-gray-950/80 backdrop-blur-sm rounded-lg flex flex-col w-full shadow-lg overflow-clip">
+                                    <div class="grid grid-cols-1">
+                                        <div class="row-[1] col-[1] text-gray-400 justify-self-center p-4 pt-3">
+                                            <img class="w-6 h-6 inline align-middle mr-2" src="{{ 'img/logo/fsharp256.png' | relative_url }}" alt="F# Logo" /><span class="align-middle text-[0.6rem] sm:text-xs ">{{ snippet.title }}</span>
+                                        </div>
+                                        <div class="row-[1] col-[1] justify-self-left self-center pl-4 ">
+                                            <div class="flex flex-row gap-2">
+                                                <div class="border-gray-600 border w-3 h-3 rounded-full" ></div>
+                                                <div class="border-gray-600 border w-3 h-3 rounded-full" ></div>
+                                                <div class="border-gray-600 border w-3 h-3 rounded-full" ></div>
+                                            </div>
+                                            
+                                        </div>
+                                        
+                                        <div class="row-[2] leading-relaxed h-96 w-full overflow-y-auto col-[1] p-4 pt-1 text-[0.5rem] sm:text-[0.8rem] lg:text-xs snippet">
+                                            {% highlight fsharp %}{{ snippet.code }}{% endhighlight %}
+                                        </div>
+                                        
+                                    </div>
+                                    <svg class="absolute left-0 top-0 w-3/6" viewBox="0 0 100 172" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0 0H100L47 172H0V0Z" fill="url(#paint0_linear_47_2)"></path><defs><linearGradient id="paint0_linear_47_2" x1="50" y1="0" x2="50" y2="100" gradientUnits="userSpaceOnUse"><stop stop-color="white" stop-opacity=".035"></stop><stop offset="1" stop-color="white" stop-opacity="0"></stop></linearGradient></defs></svg>
+                                </div>
+                                <div class="md:hidden prose prose-sm dark:prose-invert">{{ snippet.excerpt }}</div>
+                                <div class="hidden md:block prose prose-sm dark:prose-invert">{{ snippet.content }}</div>
+                            </div>
+                        </div>
+                        {% endfor %}
+                    </div> 
+                </div>
+
+                <div class="flex flex-row gap-4 justify-center items-center">
+                    <div class="xl:absolute mt-8 inset-y-0 -left-10 z-10 flex items-center">
+                        <button @click="swiper.slidePrev()" 
+                                class=" -ml-2 lg:-ml-4 flex justify-center items-center focus:outline-none">
+                                <i class="fa-solid fa-circle-chevron-left drop-shadow-md text-3xl opacity-90"></i>
+                        </button>
+                    </div>
+
+                    <div class="xl:absolute mt-8 inset-y-0 -right-10 z-10 flex items-center">
+                        <button @click="swiper.slideNext()" 
+                                class=" -mr-2 lg:-mr-4 flex justify-center items-center focus:outline-none">
+                                <i class="fa-solid fa-circle-chevron-right drop-shadow-md text-3xl opacity-90"></i>
+                        </button>
+                    </div>
+                </div>
+
+            </div>
+
+                
+        </div>
+    </section>
+
+
     <section class="home-section px-6 pt-12 pb-12 hero-pattern">
         <div class="featured max-w-6xl mx-auto">
             <!-- <h2 class="section-header mb-8 text-4xl text-center font-bold text-brand-dark">Get Started</h2> -->
@@ -73,6 +148,7 @@ keywords: F#, FSharp, F# Programming
                         <li><a class="transition hover:text-brand-dark hover:dark:text-brand-light" href="https://www.youtube.com/playlist?list=PLdo4fOcmZ0oUFghYOp89baYFBTGxUkC7Z"  target="_blank">F# for Beginners</a></li>
                         <li><a class="transition hover:text-brand-dark hover:dark:text-brand-light" href="{{ '/use/web-apps/' | relative_url }} " target="_blank">F# for JavaScript</a></li>
                     </ul>
+                    
                 </div>
                 <div class="bg-white dark:text-white dark:bg-slate-800 border border-gray-200 dark:border-gray-900 shadow-lg rounded-lg p-8">
                     <h3 class="text-2xl font-semibold"><i class="fa-solid fa-users mr-2 text-brand-dark  dark:text-brand-light mb-6"></i> Community</h3>
@@ -141,7 +217,7 @@ keywords: F#, FSharp, F# Programming
     <section class="home-section px-6">
 
         
-        <hr class="w-full"/>
+        <hr class="bg-slate-200 dark:bg-slate-800 w-full" />
 
         <div class="max-w-6xl mx-auto flex flex-col items-center">
 

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@ keywords: F#, FSharp, F# Programming
                                             
                                         </div>
                                         
-                                        <div class="row-[2] leading-relaxed h-96 w-full overflow-y-auto col-[1] p-4 pt-1 text-[0.5rem] sm:text-[0.8rem] lg:text-xs snippet">
+                                        <div class="row-[2] leading-relaxed h-96 w-full overflow-y-auto col-[1] p-4 pt-1 text-[0.8rem] sm:text-xs lg:text-md snippet">
                                             {% highlight fsharp %}{{ snippet.code }}{% endhighlight %}
                                         </div>
                                         


### PR DESCRIPTION
Added a code snippet carousel to home page.

I shared this around a bit on Bluesky and the reception was positive. One person was perhaps not sure if the "Fable" example really belonged.

I've used a Jekyll collection for the code snippets (+ accompanying explanatory markdown), so it will be straiigtforward for others to add, remove, or update the snippets.

I've added some notes to the README about this.

Can be previewed at https://ianwitham.github.io/fsharp.org/
