### PR TITLE
Update link for the book F# Applied II

### DIFF
--- a/learn/index.md
+++ b/learn/index.md
@@ -419,7 +419,7 @@ Learn how to use F#'s functional features to rapidly turn requirements into soft
 - Build simple-to-complex application behavior with F# functions
 - Interoperate between your F# applications and other .NET languages
 
-### [F# Applied II](https://www.demystifyfp.com/FsApplied2)
+### [F# Applied II](https://www.tamizhvendan.in/book/FsApplied2/)
 
 <img src="../learn/files/BookFP2.jpeg" style="float:right;margin:5px 0px 5px 25px;" />
 


### PR DESCRIPTION
At the time of this commit, the old link appears to redirect to a spam website.