### PR TITLE
Add Discourse (the forum) to the navbar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -6,12 +6,12 @@
         initDarkMode() {
             // Set up listener for system preference changes
             const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-            
+
             // Initial check based on system preference if no explicit theme is set
             if (this.theme === null && darkModeMediaQuery.matches) {
                 document.documentElement.classList.add('dark');
             }
-            
+
             // Listen for changes in system preference
             darkModeMediaQuery.addEventListener('change', (e) => {
                 if (this.theme === null) {
@@ -135,7 +135,10 @@
                             </a>
                             <a href="https://bsky.app/starter-pack/blizard.io/3la4zswhqbt2e" role="menuitem"
                                 class="group" tabindex="-1">
-                                <i class="fa-brands fa-bluesky"></i> Bluesky
+                              <i class="fa-brands fa-bluesky"></i> Bluesky
+                            </a>
+                            <a role="menuitem" class="group" href="https://forums.fsharp.org/">
+                              <i class="fa-brands fa-discourse"></i> Discourse
                             </a>
                             <a role="menuitem" class="group" href="https://www.reddit.com/r/fsharp/">
                                 <i class="fa-brands fa-reddit"></i> Reddit
@@ -189,5 +192,3 @@
 </nav>
 
 <div class="htmx-indicator" hx-preserve id="loading-strip"></div>
-
-


### PR DESCRIPTION
I've noticed https://forums.fsharp.org/ wasn't mentioned for some reason and I thought it's a good idea to add it to the navbar.