### PR TITLE
Add an .editoconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# always use spaces for indentation
+indent_style = space
+indent_size = 4
+
+[*.html]
+indent_size = 2


### PR DESCRIPTION
VS Code respects this out-of-the-box, so it should help us prevent common problems like:

- Windows line endings
- trailing space
- tabs used for indentation

As I'm using a different editor and Unix, I see a lot of space-related issues in the code, so I'd love for us to clean those up. E.g. that's how the Windows line endings show up on Unix:

<img width="918" alt="image" src="https://github.com/user-attachments/assets/a60ca934-0e6d-45d5-bb26-bf0fc9001e52" />
