### PR TITLE
Fix markdownlint configuration

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,22 +1,20 @@
 {
-  // Enable all rules by default
-  "default": true,
-
-  // Line length: increase default from 80
-  "MD013": {
-    "line_length": 100,
-    "code_blocks": false,
-    "tables": false
-  },
-
-  // Allow duplicate headers in different nested sections
-  "MD024": {
-    "allow_different_nesting": true
-  },
-
-  // Allow inline HTML
-  "MD033": false,
-
-  // First line in a file doesn't need to be a top-level header
-  "MD041": false,
+    "config": {
+        // Enable all rules by default
+        "default": true,
+        // Line length: increase default from 80
+        "MD013": {
+            "line_length": 100,
+            "code_blocks": false,
+            "tables": false
+        },
+        // Allow duplicate headers in different nested sections
+        "MD024": {
+            "allow_different_nesting": true
+        },
+        // Allow inline HTML
+        "MD033": false,
+        // First line in a file doesn't need to be a top-level header
+        "MD041": false
+    }
 }


### PR DESCRIPTION
I had missed the `config` key and the configuration was completely useless because of this. My bad!